### PR TITLE
Fix auto protocol function and productKey

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -348,25 +348,28 @@ async def validate_input(hass: core.HomeAssistant, data):
         auto_protocol = conf_protocol == "auto"
         # If 'auto' will be loop through supported protocols.
         for ver in SUPPORTED_PROTOCOL_VERSIONS:
-            version = ver if auto_protocol else conf_protocol
-            interface = await pytuya.connect(
-                data[CONF_HOST],
-                data[CONF_DEVICE_ID],
-                data[CONF_LOCAL_KEY],
-                float(version),
-                data[CONF_ENABLE_DEBUG],
-                data.get(CONF_NODE_ID, None),
-            )
-            # Break the loop if input isn't auto.
-            if not auto_protocol:
-                break
+            try:
+                version = ver if auto_protocol else conf_protocol
+                interface = await pytuya.connect(
+                    data[CONF_HOST],
+                    data[CONF_DEVICE_ID],
+                    data[CONF_LOCAL_KEY],
+                    float(version),
+                    data[CONF_ENABLE_DEBUG],
+                    data.get(CONF_NODE_ID, None),
+                )
+                # Break the loop if input isn't auto.
+                if not auto_protocol:
+                    break
 
-            detected_dps = await interface.detect_available_dps()
-            # If Auto: using DPS detected we will assume this is the correct version if dps found.
-            if len(detected_dps) > 0:
-                # Set the conf_protocol to the worked version to return it and update self.device_data.
-                conf_protocol = version
-                break
+                detected_dps = await interface.detect_available_dps()
+                # If Auto: using DPS detected we will assume this is the correct version if dps found.
+                if len(detected_dps) > 0:
+                    # Set the conf_protocol to the worked version to return it and update self.device_data.
+                    conf_protocol = version
+                    break
+            except:
+                continue
 
         if CONF_RESET_DPIDS in data:
             reset_ids_str = data[CONF_RESET_DPIDS].split(",")

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -725,6 +725,12 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
                         self.device_data[CONF_MODEL] = cloud_devs[dev_id].get(
                             CONF_PRODUCT_NAME
                         )
+                    # We add from local devices if exists because keys will re_update without it.
+                    if dev_id in self.discovered_devices.keys():
+                        self.device_data[CONF_PRODUCT_KEY] = self.discovered_devices[
+                            dev_id
+                        ].get("productKey")
+                # Handle Inputs on edit device mode.
                 if self.editing_device:
                     dev_config = {}
                     if user_input.get(EXPORT_CONFIG):
@@ -850,7 +856,6 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
                 defaults[CONF_DEVICE_ID] = device.get(CONF_TUYA_GWID)
                 defaults[CONF_PROTOCOL_VERSION] = device.get(CONF_TUYA_VERSION)
                 defaults[CONF_NODE_ID] = device.get(CONF_NODE_ID, None)
-                defaults[CONF_PRODUCT_KEY] = device.get(CONF_PRODUCT_KEY)
 
                 if dev_id in cloud_devs:
                     defaults[CONF_LOCAL_KEY] = cloud_devs[dev_id].get(CONF_LOCAL_KEY)


### PR DESCRIPTION
Fix the auto protocol function stopped after first error.

Add product key locally if available, because Using Cloud API without pk will cause double entry updates due to updating keys.