### PR TITLE
Improve English translations to be more user friendly

### DIFF
--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -18,7 +18,7 @@
         "step": {
             "user": {
                 "title": "Cloud API account configuration",
-                "description": "Configure the credentials used to connect to the Tuya Cloud API. [More Info](https://github.com/xZetsubou/hass-localtuya)",
+                "description": "Configure the credentials used to connect to the Tuya Cloud API.",
                 "data": {
                     "region": "Data Center Region",
                     "client_id": "Client ID",
@@ -77,7 +77,7 @@
             },
             "configure_cloud": {
                 "title": "Manage Cloud API account",
-                "description": "Configure the credentials used to connect to the Tuya Cloud API. [More Info](https://github.com/xZetsubou/hass-localtuya)",
+                "description": "Configure the credentials used to connect to the Tuya Cloud API.",
                 "data": {
                     "region": "Data Center Region",
                     "client_id": "Client ID",

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -56,7 +56,7 @@
                 "title": "Configuration",
                 "description": "Select an option to proceed.",
                 "menu_options": {
-                    "add_device": "Search for new devices",
+                    "add_device": "Add new device",
                     "edit_device": "Reconfigure existing device",
                     "configure_cloud": "Manage Cloud API account"
                 }

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -1,154 +1,152 @@
 {
     "config": {
         "abort": {
-            "already_configured": "This Account ID has already been configured.",
-            "device_updated": "Device configuration has been updated!"
+            "already_configured": "This account has already been configured.",
+            "device_updated": "Device configuration has been updated."
         },
         "error": {
             "authentication_failed": "Failed to authenticate.\n{msg}",
-            "cannot_connect": "Cannot connect to device. Verify that address is correct and try again.",
+            "cannot_connect": "Cannot connect to device. Confirm the IP Address is correct then try again.",
             "device_list_failed": "Failed to retrieve device list.\n{msg}",
-            "invalid_auth": "Failed to authenticate with device. Verify that device id and local key are correct.",
-            "value_error":"An error occurred: {ex}",
-            "unknown": "An unknown error occurred. See log for details {ex}",
-            "entity_already_configured": "Entity with this ID has already been configured.",
-            "address_in_use": "Address used for discovery is already in use. Make sure no other application is using it (TCP port 6668).",
-            "discovery_failed": "Something failed when discovering devices. See log for details.",
-            "empty_dps": "Connection to device succeeded but no datapoints found, please try again. Create a new issue and include debug logs if problem persists."
+            "invalid_auth": "Failed to authenticate with device. Confirm the Device Id and Local Key are correct.",
+            "unknown": "An unknown error occurred.\n{ex}.",
+            "entity_already_configured": "This entity has already been configured.",
+            "address_in_use": "TCP port 6668 (used for discovery) is already in use. Check no other integration is using it.",
+            "discovery_failed": "Something failed when discovering devices. See log for details. If problem persists, create a new issue (including debug logs).",
+            "empty_dps": "Connection to device succeeded but no datapoints could be found. Please try set-up again. If problem persists, create a new issue (including debug logs)."
         },
         "step": {
             "user": {
                 "title": "Cloud API account configuration",
-                "description": "[Input the credentials for Tuya Cloud API. (Docs)](https://github.com/xZetsubou/hass-localtuya)",
+                "description": "Configure the credentials used to connect to the Tuya Cloud API. [More Info](https://github.com/xZetsubou/hass-localtuya)",
                 "data": {
-                    "region": "API server region",
+                    "region": "Data Center Region",
                     "client_id": "Client ID",
-                    "client_secret": "Secret",
+                    "client_secret": "Client Secret",
                     "user_id": "User ID",
                     "user_name": "Username",
-                    "no_cloud": "Do not configure a Cloud API account"
+                    "no_cloud": "Disable Cloud API?"
                 }
             }
         }
     },
     "options": {
         "abort": {
-            "already_configured": "This Account ID has already been configured.",
+            "already_configured": "This account has already been configured.",
             "device_success": "Device {dev_name} successfully {action}.",
-            "no_entities": "Cannot remove all entities from a device.\nIf you want to delete a device, enter it in the Devices menu, click the 3 dots in the 'Device info' frame, and press the Delete button."
+            "no_entities": "Cannot remove all entities from a device.\nIf you want to delete a device: Browse to `Devices & services` menu, search for your device in `Devices` tab, click the 3 dots in the `Device info` frame, and press the `Delete` button."
         },
         "error": {
             "authentication_failed": "Failed to authenticate.\n{msg}",
-            "cannot_connect": "Cannot connect to device. Verify that address is correct and try again.",
+            "cannot_connect": "Cannot connect to device. Confirm the IP Address is correct then try again.",
             "device_list_failed": "Failed to retrieve device list.\n{msg}",
-            "invalid_auth": "Failed to authenticate with device. Verify that device id and local key are correct.",
-            "value_error":"An error occurred: {ex}",
-            "unknown": "An unknown error occurred. See log for details \n{ex}.",
-            "entity_already_configured": "Entity with this ID has already been configured.",
-            "address_in_use": "Address used for discovery is already in use. Make sure no other application is using it (TCP port 6668).",
-            "discovery_failed": "Something failed when discovering devices. See log for details.",
-            "empty_dps": "Connection to device succeeded but an issue happend!, please try again, check the logs for Create a new issue and include debug logs if problem persists."
+            "invalid_auth": "Failed to authenticate with device. Confirm the Device Id and Local Key are correct.",
+            "unknown": "An unknown error occurred. \n{ex}.",
+            "entity_already_configured": "This entity has already been configured.",
+            "address_in_use": "TCP port 6668 (used for discovery) is already in use. Check no other integration is using it.",
+            "discovery_failed": "Something failed when discovering devices. See log for details. If problem persists, create a new issue (including debug logs).",
+            "empty_dps": "Connection to device succeeded but no datapoints could be found. Please try set-up again. If problem persists, create a new issue (including debug logs)."
         },
         "step": {
             "yaml_import": {
-                "title": "Not Supported",
-                "description": "Options cannot be edited when configured via YAML."
+                "title": "Not supported",
+                "description": "Devices configured using `YAML` cannot be configured in the UI. Delete your device from `YAML` and re-create it in the UI or modify your `YAML` configuration."
             },
             "init": {
-                "title": "LocalTuya Configuration",
-                "description": "Please choose the desired action.",
+                "title": "Configuration",
+                "description": "Select an option to proceed.",
                 "menu_options": {
-                    "add_device": "Add a new device",
-                    "edit_device": "Edit a device",
-                    "configure_cloud": "Reconfigure Cloud API account"
+                    "add_device": "Search for new devices",
+                    "edit_device": "Reconfigure existing device",
+                    "configure_cloud": "Manage Cloud API account"
                 }
             },
             "add_device": {
-                "title": "Add a new device",
-                "description": "Pick one of the automatically discovered devices or Add Device Manually.",
+                "title": "Choose device to configure",
+                "description": "Compatible Tuya devices on your local network are discovered automatically once they have been set-up in the Tuya app. If you can't see the device you expected, choose `Add device manually` from the dropdown.",
                 "data": {
-                    "selected_device": "Discovered Devices"
+                    "selected_device": "Discovered devices"
                 }
             },
             "edit_device": {
-                "title": "Edit a new device",
-                "description": "Pick the configured device you wish to edit.",
+                "title": "Reconfigure existing device",
+                "description": "Select the device you wish to re-configure.",
                 "data": {
-                    "selected_device": "Configured Devices"
+                    "selected_device": "Configured devices"
                 }
             },
             "configure_cloud": {
-                "title": "Cloud API account configuration",
-                "description": "Input the credentials for Tuya Cloud API.",
+                "title": "Manage Cloud API account",
+                "description": "Configure the credentials used to connect to the Tuya Cloud API. [More Info](https://github.com/xZetsubou/hass-localtuya)",
                 "data": {
-                    "region": "API server region",
+                    "region": "Data Center Region",
                     "client_id": "Client ID",
-                    "client_secret": "Secret",
+                    "client_secret": "Client Secret",
                     "user_id": "User ID",
                     "user_name": "Username",
-                    "no_cloud": "Do not configure Cloud API account"
+                    "no_cloud": "Disable Cloud API?"
                 }
             },
             "configure_device": {
-                "title": "Configure Tuya device",
-                "description": "Fill in the device details{for_device}.",
+                "title": "Configure device connectivity",
+                "description": "Configure any device details{for_device} that are empty (if any) to allow LocalTuya to connect to the device.",
                 "data": {
-                    "friendly_name": "Name",
-                    "host": "Host",
+                    "friendly_name": "Device Name",
+                    "host": "IP Address",
                     "device_id": "Device ID",
-                    "local_key": "Local key",
-                    "node_id": "Node_ID Only for sub devices",
+                    "local_key": "Local Key",
+                    "node_id": "(Optional) Sub-devices Node Id",
                     "protocol_version": "Protocol Version",
-                    "enable_debug": "Enable debugging for this device (debug must be enabled also in configuration.yaml)",
-                    "scan_interval": "Scan interval (seconds, only when not updating automatically)",
-                    "entities": "Entities (uncheck an entity to remove it)",
-                    "add_entities": "Add more entities in 'edit device' mode",
-                    "manual_dps_strings": "Manual DPS to add (separated by commas ',') - used when detection is not working (optional)",
-                    "reset_dpids": "DPIDs to send in RESET command (separated by commas ',')- Used when device does not respond to status requests after turning on (optional)",
-                    "export_config": "Export the device config."
+                    "enable_debug": "Enable debug (must be manually enabled in `configuration.yaml` too)",
+                    "scan_interval": "(Optional) Scan interval in seconds, if not scanning automatically",
+                    "entities": "Configured entities (uncheck to delete)",
+                    "add_entities": "Add new entity(s)",
+                    "manual_dps_strings": "(Optional) Manual DPS's, if not detected automatically (separated by commas)",
+                    "reset_dpids": "(Optional) DPIDs to send in RESET command, if device does not respond to status requests after turning on (separated by commas)",
+                    "export_config": "Save entity configuration as template"
                 }
             },
             "device_setup_method": {
-                "title": "Configure device method",
-                "description": "Pick the setup method for the device auto works similar to HA tuya integration",
+                "title": "Configure device entities",
+                "description": "LocalTuya will try to discover the rest of the configuration automatically. However, if this does not work for your device or you would like to tweak settings, choose the `manual` option.",
                 "menu_options": {
-                    "auto_configure_device":"Auto Configure (Beta)",
-                    "pick_entity_type": "Setup Manually (Advanced)",
-                    "choose_template":"Use Template (Pre-Config)"
+                    "auto_configure_device":"Discover device entities automatically (BETA)",
+                    "pick_entity_type": "Configure device entities manually",
+                    "choose_template":"Use saved template"
                 }
             },
             "auto_configure_device": {
-                "title": "Auto Configure",
-                "description": "An Error occurred: {err_msg}, if reason isn't showing check logs",
+                "title": "Auto configure",
+                "description": "An error occurred: {err_msg}. If reason isn't showing, check logs.",
                 "menu_options": {
                     "device_setup_method":"Return to Setup method"
                 }
             },
             "pick_entity_type": {
                 "title": "Entity type selection",
-                "description": "Please pick the type of entity you want to add.",
+                "description": "Choose the type of entity you want to add.",
                 "data": {
-                    "platform_to_add": "Platform",
-                    "no_additional_entities": "Do not add any more entities",
+                    "platform_to_add": "Choose entity",
+                    "no_additional_entities": "Finish configuring entities",
                     "use_template" : "Import template file"
                 }
             },
             "choose_template":{
-                "title": "Template selection",
-                "description": "[Template files are located in the templates directory! (Click for Wiki)](https://github.com/xZetsubou/hass-localtuya/discussions/13)",
+                "title": "Import template file",
+                "description": "Template files are located in the `templates` directory.",
                 "data": {
-                    "templates": "Template"
+                    "templates": "Choose template"
                 },
                 "data_description": {
-                    "templates": "Pick a template from the list above"
+                    "templates": "Templates can be found and shared with others on GitHub ([More Info](https://github.com/xZetsubou/hass-localtuya/discussions/13))."
                 }
             },
             "configure_entity": {
                 "title": "Configure entity",
-                "description": "Please fill out the details for {entity} with type `{platform}`. All settings except for `ID` can be changed from the Options page later.",
+                "description": "Please fill out the details for {entity} with type {platform}. All settings (except for `Type` and `ID`) can be changed from the `Configure` page later.",
                 "data": {
-                    "id": "ID",
-                    "friendly_name": "Friendly name for entity (device_name_entity name)",
+                    "id": "DP ID",
+                    "friendly_name": "Friendly name for Entity",
                     "current": "Current",
                     "current_consumption": "Current Consumption",
                     "voltage": "Voltage",
@@ -158,52 +156,52 @@
                     "set_position_dp": "Set Position (for *position* mode only)",
                     "position_inverted": "Invert 0-100 position (for *position* mode only)",
                     "span_time": "Full opening time, in secs. (for *timed* mode only)",
-                    "unit_of_measurement": "Unit of Measurement (Optional)",
-                    "device_class": "Device Class (Optional)",
-                    "state_class": "State Class (Optional)",
+                    "unit_of_measurement": "Unit of Measurement (optional)",
+                    "device_class": "(Optional) Device Class",
+                    "state_class": "(Optional) State Class",
                     "scaling": "Scaling Factor",
                     "state_on": "On Value",
                     "state_off": "Off Value",
-                    "powergo_dp": "Power DP (Usually 25 or 2)",
+                    "powergo_dp": "Power DP (usually 25 or 2)",
                     "idle_status_value": "Idle Status (comma-separated)",
                     "returning_status_value": "Returning Status",
                     "docked_status_value": "Docked Status (comma-separated)",
-                    "fault_dp": "Fault DP (Usually 11)",
-                    "battery_dp": "Battery status DP (Usually 14)",
-                    "mode_dp": "Mode DP (Usually 27)",
+                    "fault_dp": "Fault DP (usually 11)",
+                    "battery_dp": "Battery status DP (usually 14)",
+                    "mode_dp": "Mode DP (usually 27)",
                     "modes": "Modes list",
                     "return_mode": "Return home mode",
-                    "fan_speed_dp": "Fan speeds DP (Usually 30)",
+                    "fan_speed_dp": "Fan speeds DP (usually 30)",
                     "fan_speeds": "Fan speeds list (comma-separated)",
-                    "clean_time_dp": "Clean Time DP (Usually 33)",
-                    "clean_area_dp": "Clean Area DP (Usually 32)",
-                    "clean_record_dp": "Clean Record DP (Usually 34)",
-                    "locate_dp": "Locate DP (Usually 31)",
+                    "clean_time_dp": "Clean Time DP (usually 33)",
+                    "clean_area_dp": "Clean Area DP (usually 32)",
+                    "clean_record_dp": "Clean Record DP (usually 34)",
+                    "locate_dp": "Locate DP (usually 31)",
                     "paused_state": "Pause state (pause, paused, etc)",
                     "stop_status": "Stop status",
                     "brightness": "Brightness (only for white color)",
                     "brightness_lower": "Brightness Lower Value",
                     "brightness_upper": "Brightness Upper Value",
                     "color_temp": "Color Temperature",
-                    "color_temp_reverse": "Color Temperature Reverse",
+                    "color_temp_reverse": "Reverse Color Temperature?",
                     "color": "Color",
                     "color_mode": "Color Mode aka Work Mode",
                     "color_temp_min_kelvin": "Minimum Color Temperature in K",
                     "color_temp_max_kelvin": "Maximum Color Temperature in K",
-                    "music_mode": "Music mode available",
+                    "music_mode": "Music mode available?",
                     "scene": "Scene",
                     "scene_values": "Scene values, separate entries by comma ','",
                     "scene_values_friendly": "User friendly scene values, separate entries by comma ','",
                     "select_options": "Valid entries, separate entries by comma ','",
                     "select_options_friendly": "User Friendly options, separate entries by comma ','",
-                    "fan_speed_control": "Fan Speed Control dps",
-                    "fan_oscillating_control": "Fan Oscillating Control dps",
+                    "fan_speed_control": "Fan Speed Control DP",
+                    "fan_oscillating_control": "Fan Oscillating Control DP",
                     "fan_speed_min": "minimum fan speed integer",
                     "fan_speed_max": "maximum fan speed integer",
                     "fan_speed_ordered_list": "Fan speed modes list (overrides speed min/max)",
-                    "fan_direction":"fan direction dps",
-                    "fan_direction_forward": "forward dps string",
-                    "fan_direction_reverse": "reverse dps string",
+                    "fan_direction":"Fan Direction DP",
+                    "fan_direction_forward": "Forward DP string",
+                    "fan_direction_reverse": "Reverse DP string",
                     "fan_dps_type": "DP value type",
                     "current_temperature_dp": "Current Temperature",
                     "target_temperature_dp": "Target Temperature",
@@ -211,7 +209,7 @@
                     "max_temp": "Max Temperature (Number)",
                     "min_temp": "Min Temperature (Number)",
                     "precision": "Precision (optional, for DPs values)",
-                    "target_precision": "Target Precision (optional, for DPs values)",
+                    "target_precision": "Target Precision (optional, for DP values)",
                     "temperature_unit": "Temperature Unit (optional)",
                     "hvac_mode_dp": "HVAC Mode DP (optional)",
                     "hvac_mode_set": "HVAC Mode Set (optional)",
@@ -222,17 +220,17 @@
                     "eco_dp": "Eco DP (optional)",
                     "eco_value": "Eco value (optional)",
                     "heuristic_action": "Enable heuristic action (optional)",
-                    "dps_default_value": "Default value when un-initialised (optional)",
-                    "restore_on_reconnect": "Restore the last set value in HomeAssistant after a lost connection",
+                    "dps_default_value": "(Optional) Default value when un-initialised",
+                    "restore_on_reconnect": "Restore the last value set in Home Assistant after lost connection?",
                     "min_value": "Minimum Value",
                     "max_value": "Maximum Value",
                     "step_size": "Minimum increment between numbers",
-                    "is_passive_entity": "Passive entity - requires integration to send initialisation value",
-                    "entity_category": "Show the entity in this categroy"
+                    "is_passive_entity": "Passive entity? (requires integration to send initialisation value)",
+                    "entity_category": "Show the entity in this category"
                 },
                 "data_description": {
-                    "device_class": "[Device Classes: More Info](https://www.home-assistant.io/docs/configuration/customizing-devices/#device-class)",
-                    "state_class": "[State Classes: More Info](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes)"
+                    "device_class": "Find out more about [Device Classes](https://www.home-assistant.io/docs/configuration/customizing-devices/#device-class)",
+                    "state_class": "Find out more about [State Classes](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes)"
                 }
             }
         }


### PR DESCRIPTION
I'm reasonably technically inclined but struggled the first time I ever set-up the original LocalTuya integration. This PR proposes to make some changes to the translations to make the first time set-up easier for those new users by clearly identifying everything that is optional or advanced and more clearly outlining how to complete set-up.