### PR TITLE
Improve entry initialization

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -496,7 +496,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
             self.warning(f"Disconnected - waiting for discovery broadcast")
             # Try to quickly reconnect.
             self._is_closing = False
-            self._hass.create_task(self.async_connect())
+            self._hass.async_create_task(self.async_connect())
 
 
 class LocalTuyaEntity(RestoreEntity, pytuya.ContextualLogger):


### PR DESCRIPTION
* Setup API, Now execute in background without interrupt the initialization.
* Unloading platforms now get the platform from `hass.data.....[TUYA_DEVICES]` resolves #43 

On unloading: Platforms was pulled from `entry.data` this causing an error of `config entry was never loaded` because when we add first platform, `entry.data` would have the platform but it actually was never loaded since it first time added.

While we pull platforms from `TUYA_DEVICE` data we also store `close()` to call it after unload, instead of doing 2 loops.