### PR TITLE
Improves config flow

### DIFF
--- a/custom_components/localtuya/cloud_api.py
+++ b/custom_components/localtuya/cloud_api.py
@@ -125,7 +125,9 @@ class TuyaCloudApi:
             return f"Error {r_json['code']}: {r_json['msg']}"
 
         req_results = r_json["result"]
-        self._token_expire_time = int(time.time()) + int(req_results.get("expire_time"))
+
+        expire_time = int(req_results.get("expire_time", 3600))
+        self._token_expire_time = int(time.time()) + expire_time
         self._access_token = resp.json()["result"]["access_token"]
         return "ok"
 

--- a/custom_components/localtuya/cloud_api.py
+++ b/custom_components/localtuya/cloud_api.py
@@ -148,7 +148,7 @@ class TuyaCloudApi:
 
         self.device_list = {dev["id"]: dev for dev in r_json["result"]}
 
-        # Pull DPS Data.
+        # Get Devices DPS Data.
         get_functions = [self.get_device_functions(devid) for devid in self.device_list]
         await asyncio.gather(*get_functions)
 

--- a/custom_components/localtuya/cloud_api.py
+++ b/custom_components/localtuya/cloud_api.py
@@ -38,7 +38,7 @@ class TuyaCloudApi:
         self._secret = secret
         self._user_id = user_id
         self._access_token = ""
-        self._token_expire_time: int = -1
+        self._token_expire_time: int = 0
 
         self.device_list = {}
 

--- a/custom_components/localtuya/cloud_api.py
+++ b/custom_components/localtuya/cloud_api.py
@@ -1,4 +1,5 @@
 """Class to perform requests to Tuya Cloud APIs."""
+import asyncio
 import functools
 import hashlib
 import hmac
@@ -146,7 +147,10 @@ class TuyaCloudApi:
             return f"Error {r_json['code']}: {r_json['msg']}"
 
         self.device_list = {dev["id"]: dev for dev in r_json["result"]}
-        # _LOGGER.debug("DEV_LIST: %s", self.device_list)
+
+        # Pull DPS Data.
+        get_functions = [self.get_device_functions(devid) for devid in self.device_list]
+        await asyncio.gather(*get_functions)
 
         return "ok"
 
@@ -179,6 +183,25 @@ class TuyaCloudApi:
             return {}, f"Error {r_json['code']}: {r_json['msg']}"
 
         return r_json["result"], "ok"
+
+    async def get_device_functions(self, device_id):
+        """Pull Devices Properties and Specifications to devices_list"""
+        get_data = [
+            self.async_get_device_specifications(device_id),
+            self.async_get_device_query_properties(device_id),
+        ]
+        specs, query_props = await asyncio.gather(*get_data)
+        if query_props[1] == "ok":
+            device_data = {str(p["dp_id"]): p for p in query_props[0].get("properties")}
+        if specs[1] == "ok":
+            for func in specs[0].get("functions"):
+                if str(func["dp_id"]) in device_data:
+                    device_data[str(func["dp_id"])].update(func)
+
+        if device_data:
+            self.device_list[device_id]["dps_data"] = device_data
+
+        return device_data
 
     @property
     def token_validate(self):

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -577,6 +577,9 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Manage basic options."""
         self.cloud_data = self.hass.data[DOMAIN][self.config_entry.entry_id][DATA_CLOUD]
+        if not self.config_entry.data.get(CONF_NO_CLOUD):
+            # Refresh devices List data.
+            self.hass.async_create_task(self.cloud_data.async_get_devices_list())
 
         return self.async_show_menu(
             step_id="init",
@@ -1008,16 +1011,6 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
         schema = PICK_TEMPLATE
         return self.async_show_form(step_id="choose_template", data_schema=schema)
 
-    def available_dps_strings(self):
-        """Return list of DPs use by the device's entities."""
-        available_dps = []
-        used_dps = [str(entity[CONF_ID]) for entity in self.entities]
-        for dp_string in self.dps_strings:
-            dp = dp_string.split(" ")[0]
-            if dp not in used_dps:
-                available_dps.append(dp_string)
-        return available_dps
-
     async def async_step_entity(self, user_input=None):
         """Manage entity settings."""
         errors = {}
@@ -1127,6 +1120,16 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
         # if user_input is not None:
         #     return self.async_create_entry(title="", data={})
         # return self.async_show_form(step_id="yaml_import")
+
+    def available_dps_strings(self):
+        """Return list of DPs use by the device's entities."""
+        available_dps = []
+        used_dps = [str(entity[CONF_ID]) for entity in self.entities]
+        for dp_string in self.dps_strings:
+            dp = dp_string.split(" ")[0]
+            if dp not in used_dps:
+                available_dps.append(dp_string)
+        return available_dps
 
     @property
     def current_entity(self):

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -1469,7 +1469,7 @@ async def connect(
         if ex.errno == errno.EHOSTUNREACH:
             raise ValueError(f"The host is unreachable")
     except:
-        raise ValueError(f"unknown error: See the logs for details.")
+        raise ValueError(f"Unknown error See the logs for details.")
 
     await asyncio.wait_for(on_connected, timeout=timeout)
     return protocol

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -1469,7 +1469,7 @@ async def connect(
         if ex.errno == errno.EHOSTUNREACH:
             raise ValueError(f"The host is unreachable")
     except:
-        raise ValueError(f"Unknown, Maybe port is closed for this host?.")
+        raise ValueError(f"unknown error: See the logs for details.")
 
     await asyncio.wait_for(on_connected, timeout=timeout)
     return protocol


### PR DESCRIPTION
* DPS Data now will be pulled with devices data, data stored in `device_id` -> in `devices_list` with `dps_data` key.
* Adding new device DPS Data will be pulled from stored data `except the value!`
* Devices list in config flow now will be sorted: Starting from known devices first.
* Refresh cloud devices data when configure opened. `previously reload was needed in order to pull new devices data.`
* Handle the errors if refreshing token failed.