### PR TITLE
Templates manually enter the filenames

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -125,7 +125,7 @@ PICK_TEMPLATE = vol.Schema(
             default=list(templates.list_templates().values())[0]
             if templates.list_templates()
             else "No templates found.",
-        ): _col_to_select(templates.list_templates())
+        ): _col_to_select(templates.list_templates(), custom_value=True)
     }
 )
 
@@ -149,17 +149,10 @@ def devices_schema(
 
         devices[f"{dev_name} ({dev_host})"] = dev_id
 
-    if add_custom_device:
-        devices.update(CUSTOM_DEVICE)
-
     known_devices = {k: v for k, v in sorted(known_devices.items())}
     devices = {**known_devices, **devices}
-    # devices.update(
-    #     {
-    #         ent.data[CONF_DEVICE_ID]: ent.data[CONF_FRIENDLY_NAME]
-    #         for ent in entries
-    #     }
-    # )
+    if add_custom_device:
+        devices.update(CUSTOM_DEVICE)
     return vol.Schema(
         {
             vol.Required(

--- a/custom_components/localtuya/core/helpers.py
+++ b/custom_components/localtuya/core/helpers.py
@@ -30,8 +30,8 @@ class templates:
         for p, d, f in os.walk(dir):
             for file in sorted(f):
                 if fnmatch(file, "*yaml") or fnmatch(file, "*yml"):
-                    fn = str(file).replace(".yaml", "").replace("_", " ")
-                    files[fn.capitalize()] = file
+                    # fn = str(file).replace(".yaml", "").replace("_", " ")
+                    files[file] = file
         return files
 
     def import_config(filename):
@@ -39,7 +39,7 @@ class templates:
         template_dir = os.path.dirname(templates_dir.__file__)
         template_file = os.path.join(template_dir, filename)
         _config = load_yaml(template_file)
-        entity = []
+        entities = []
         for cfg in _config:
             ent = {}
             for plat, values in cfg.items():
@@ -50,8 +50,10 @@ class templates:
                         else value
                     )
                 ent[CONF_PLATFORM] = plat
-            entity.append(ent)
-        return entity
+            entities.append(ent)
+        if not entities:
+            raise ValueError("No entities found the can be used for localtuya")
+        return entities
 
     @classmethod
     def export_config(cls, config, config_name: str):
@@ -93,7 +95,7 @@ from homeassistant.helpers.selector import (
 )
 
 
-def _col_to_select(opt_list, multi_select=False, is_dps=False):
+def _col_to_select(opt_list, multi_select=False, is_dps=False, custom_value=False):
     """Convert collections to SelectSelectorConfig."""
     if type(opt_list) == dict:
         return SelectSelector(
@@ -102,6 +104,7 @@ def _col_to_select(opt_list, multi_select=False, is_dps=False):
                     SelectOptionDict(value=str(v), label=k) for k, v in opt_list.items()
                 ],
                 mode=SelectSelectorMode.DROPDOWN,
+                custom_value=custom_value,
             )
         )
     elif type(opt_list) == list:

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -138,7 +138,7 @@
                     "templates": "Choose template"
                 },
                 "data_description": {
-                    "templates": "Templates can be found and shared with others on GitHub ([More Info](https://github.com/xZetsubou/hass-localtuya/discussions/13))."
+                    "templates": "You can enter the file name manually if it didn't shows up.\nTemplates can be found and shared with others on GitHub ([More Info](https://github.com/xZetsubou/hass-localtuya/discussions/13))."
                 }
             },
             "configure_entity": {


### PR DESCRIPTION
* Templates list field are now insertable and searchable, so if you add templates new template into `templates` directory you can manually enter there name without need to load them up with HA boot.
* Templates names now will shows the same as filename with extension.

