### PR TITLE
* Refactor codes a little bit to make it easier to maintain.

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -3,8 +3,9 @@ import asyncio
 import logging
 import time
 from datetime import timedelta
+from typing import NamedTuple, Coroutine
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, CALLBACK_TYPE, callback
 from homeassistant.config_entries import ConfigEntry
 
 from homeassistant.const import (
@@ -23,15 +24,15 @@ from homeassistant.const import (
     CONF_TYPE,
     CONF_ICON,
 )
-from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import async_track_time_interval, async_call_later
 from homeassistant.helpers.restore_state import RestoreEntity
 
+from .cloud_api import TuyaCloudApi
 from .core import pytuya
 from .const import (
     ATTR_STATE,
@@ -45,9 +46,7 @@ from .const import (
     CONF_PROTOCOL_VERSION,
     CONF_RESET_DPIDS,
     CONF_RESTORE_ON_RECONNECT,
-    DATA_CLOUD,
     DOMAIN,
-    TUYA_DEVICES,
     DEFAULT_CATEGORIES,
     ENTITY_CATEGORY,
     CONF_GATEWAY_ID,
@@ -99,8 +98,7 @@ async def async_setup_entry(
         if entities_to_setup:
             if node_id := dev_entry.get(CONF_NODE_ID):
                 host = f"{host}_{node_id}"
-
-            tuyainterface = hass.data[DOMAIN][config_entry.entry_id][TUYA_DEVICES][host]
+            tuyainterface = hass.data[DOMAIN][config_entry.entry_id].tuya_devices[host]
 
             dps_config_fields = list(get_dps_for_platform(flow_schema))
 
@@ -159,17 +157,18 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         hass: HomeAssistant,
         config_entry: ConfigEntry,
         dev_id: str,
-        gateway=False,
+        fake_gateway=False,
     ):
         """Initialize the cache."""
         super().__init__()
         self._hass = hass
+        self._hass_entry: HassLocalTuyaData = None
         self._config_entry = config_entry
         self._device_config: dict = config_entry.data[CONF_DEVICES][dev_id].copy()
         self._interface = None
         # For SubDevices
         self._node_id: str = self._device_config.get(CONF_NODE_ID)
-        self._fake_gateway = gateway
+        self._fake_gateway = fake_gateway
         self._gwateway: TuyaDevice = None
         self._sub_devices = {}
 
@@ -224,7 +223,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
             return
         entry_id = self._config_entry.entry_id
         node_host = self._device_config.get(CONF_HOST)
-        devices: dict = self._hass.data[DOMAIN][entry_id][TUYA_DEVICES]
+        devices: dict = self._hass_entry.tuya_devices
 
         # Sub to gateway.
         if gateway := devices.get(node_host):
@@ -237,6 +236,8 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
     async def async_connect(self):
         """Connect to device if not already connected."""
+        if not self._hass_entry:
+            self._hass_entry = self._hass.data[DOMAIN][self._config_entry.entry_id]
         # self.info("async_connect: %d %r %r", self._is_closing, self._connect_task, self._interface)
         # if not self._is_closing and self._connect_task is None and not self._interface:
         if not self._is_closing and not self.is_connecting and not self.connected:
@@ -299,7 +300,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 self.status_updated(status)
 
             except UnicodeDecodeError as e:  # pylint: disable=broad-except
-                self.exception(f"Connect to {host} failed: {type(e)}")
+                self.exception(f"Connect to {host} failed: due to: {type(e)}")
 
                 await self.abort_connect()
 
@@ -361,9 +362,9 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
     async def update_local_key(self):
         """Retrieve updated local_key from Cloud API and update the config_entry."""
         dev_id = self._device_config[CONF_DEVICE_ID]
-        entry_id = self._config_entry.entry_id
-        await self._hass.data[DOMAIN][entry_id][DATA_CLOUD].async_get_devices_list()
-        cloud_devs = self._hass.data[DOMAIN][entry_id][DATA_CLOUD].device_list
+        cloud_api = self._hass_entry.cloud_data
+        await cloud_api.async_get_devices_list()
+        cloud_devs = cloud_api.device_list
         if dev_id in cloud_devs:
             self._local_key = cloud_devs[dev_id].get(CONF_LOCAL_KEY)
             new_data = self._config_entry.data.copy()
@@ -496,7 +497,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
             self.warning(f"Disconnected - waiting for discovery broadcast")
             # Try to quickly reconnect.
             self._is_closing = False
-            self._hass.async_create_task(self.async_connect())
+            async_call_later(self._hass, 2, self.async_connect)
 
 
 class LocalTuyaEntity(RestoreEntity, pytuya.ContextualLogger):
@@ -742,3 +743,11 @@ class LocalTuyaEntity(RestoreEntity, pytuya.ContextualLogger):
 
         # Manually initialise
         await self._device.set_dp(restore_state, self._dp_id)
+
+
+class HassLocalTuyaData(NamedTuple):
+    """LocalTuya data stored in homeassistant data object."""
+
+    cloud_data: TuyaCloudApi
+    tuya_devices: dict[str, TuyaDevice]
+    unsub_listeners: list[CALLBACK_TYPE,]

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -4,7 +4,6 @@ from homeassistant.const import EntityCategory, Platform
 DOMAIN = "localtuya"
 
 DATA_DISCOVERY = "discovery"
-DATA_CLOUD = "cloud_data"
 
 # Order on priority
 SUPPORTED_PROTOCOL_VERSIONS = ["3.3", "3.1", "3.2", "3.4", "3.5"]
@@ -26,7 +25,6 @@ PLATFORMS = {
     "Switch": Platform.SWITCH,
     "Vacuum": Platform.VACUUM,
 }
-TUYA_DEVICES = "tuya_devices"
 
 ATTR_CURRENT = "current"
 ATTR_CURRENT_CONSUMPTION = "current_consumption"

--- a/custom_components/localtuya/diagnostics.py
+++ b/custom_components/localtuya/diagnostics.py
@@ -10,7 +10,8 @@ from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_DEVICES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import CONF_LOCAL_KEY, CONF_USER_ID, DATA_CLOUD, DOMAIN
+from .const import CONF_LOCAL_KEY, CONF_USER_ID, DOMAIN
+from .common import HassLocalTuyaData
 
 CLOUD_DEVICES = "cloud_devices"
 DEVICE_CONFIG = "device_config"
@@ -25,7 +26,8 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     data = {}
     data = dict(entry.data)
-    tuya_api = hass.data[DOMAIN][entry.entry_id][DATA_CLOUD]
+    hass_localtuya: HassLocalTuyaData = hass.data[DOMAIN][entry.entry_id]
+    tuya_api = hass_localtuya.cloud_data
     # censoring private information on integration diagnostic data
     for field in [CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_USER_ID]:
         data[field] = f"{data[field][0:3]}...{data[field][-3:]}"
@@ -53,7 +55,8 @@ async def async_get_device_diagnostics(
     # local_key = data[DEVICE_CONFIG][CONF_LOCAL_KEY]
     # data[DEVICE_CONFIG][CONF_LOCAL_KEY] = f"{local_key[0:3]}...{local_key[-3:]}"
 
-    tuya_api = hass.data[DOMAIN][entry.entry_id][DATA_CLOUD]
+    hass_localtuya: HassLocalTuyaData = hass.data[DOMAIN][entry.entry_id]
+    tuya_api = hass_localtuya.cloud_data
     if dev_id in tuya_api.device_list:
         data[DEVICE_CLOUD_INFO] = tuya_api.device_list[dev_id]
         # NOT censoring private information on device diagnostic data


### PR DESCRIPTION
* cloud_api now has async_connect function.
* Localtuya HASS Data is now stored as namedtuple `HassLocalTuyaData`
* Removed `TUYA_DEVICES`, `DATA_CLOUD` and `UNSUB LISTENERS`
* Sotred all unsub_callback in tuya_devices.unsub_listeners
* Reconnect if disconnected will be called after 2secounds.