### PR TITLE
Fix: `set dp service` and support multi list of set_dp

### DIFF
--- a/custom_components/localtuya/services.yaml
+++ b/custom_components/localtuya/services.yaml
@@ -23,7 +23,7 @@ set_dp:
           mode: box
     value:
       name: "Value"
-      description: New value to set
+      description: "New value to set or list of dp: value, If value is list target dp will be ignored"
       required: true
       example: "true"
       selector:


### PR DESCRIPTION
example:

```yaml
service: localtuya.set_dp
data:
  device_id: bf3e040669bd7aa117owie
  value: 
    - 1: false
    - 2: true
    - 3: true
```