### PR TITLE
Disconnected msg level and fix Translation `username`

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -493,7 +493,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
         # If it's disconnect by unexpected error.
         if self._is_closing is not True and not self.is_subdevice:
-            self.warning(f"Disconnected - waiting for discovery broadcast")
+            self.info(f"Disconnected - waiting for discovery broadcast")
             # Try to quickly reconnect.
             self._is_closing = False
             async_call_later(self._hass, 2, self.async_connect)

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -24,7 +24,7 @@
                     "client_id": "Client ID",
                     "client_secret": "Client Secret",
                     "user_id": "User ID",
-                    "user_name": "Username",
+                    "username": "Username",
                     "no_cloud": "Disable Cloud API?"
                 }
             }


### PR DESCRIPTION
* Fix: translations `username`
* Disconnected msg from "Warning" to "INFO"