### PR TITLE
Set `Switch` as default class for switches

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -625,7 +625,7 @@ class LocalTuyaEntity(RestoreEntity, pytuya.ContextualLogger):
     @property
     def device_class(self):
         """Return the class of this device."""
-        return self._config.get(CONF_DEVICE_CLASS, None)
+        return self._config.get(CONF_DEVICE_CLASS, self._attr_device_class)
 
     def has_config(self, attr) -> bool:
         """Return if a config parameter has a valid value."""

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -47,6 +47,8 @@ def flow_schema(dps):
 class LocaltuyaSwitch(LocalTuyaEntity, SwitchEntity):
     """Representation of a Tuya switch."""
 
+    _attr_device_class = SwitchDeviceClass.SWITCH
+
     def __init__(
         self,
         device,


### PR DESCRIPTION
Fix: switch icon changes depends on state