### PR TITLE
Skip decryption of broadcast message with UDP command

### DIFF
--- a/custom_components/localtuya/core/tuya_devices/climates.py
+++ b/custom_components/localtuya/core/tuya_devices/climates.py
@@ -80,7 +80,7 @@ CLIMATES: dict[str, tuple[LocalTuyaEntity, ...]] = {
                 values_precsion=0.1,
                 target_precision=0.1,
             ),
-        )
+        ),
     ),
     # Heater
     # https://developer.tuya.com/en/docs/iot/f?id=K9gf46epy4j82
@@ -98,7 +98,7 @@ CLIMATES: dict[str, tuple[LocalTuyaEntity, ...]] = {
                 target_precision=0.1,
                 preset_set="auto/smart",
             ),
-        )
+        ),
     ),
     # Heater
     # https://developer.tuya.com/en/docs/iot/categoryrs?id=Kaiuz0nfferyx

--- a/custom_components/localtuya/discovery.py
+++ b/custom_components/localtuya/discovery.py
@@ -23,6 +23,7 @@ UDP_KEY = md5(b"yGAdlopoPVldABfn").digest()
 
 PREFIX_55AA_BIN = b"\x00\x00U\xaa"
 PREFIX_6699_BIN = b"\x00\x00\x66\x99"
+UDP_COMMAND = b"\x00\x00\x00\x00"
 
 DEFAULT_TIMEOUT = 6.0
 
@@ -37,7 +38,10 @@ def decrypt(msg, key):
 def decrypt_udp(message):
     """Decrypt encrypted UDP broadcasts."""
     if message[:4] == PREFIX_55AA_BIN:
-        return decrypt(message[20:-8], UDP_KEY)
+        payload = message[20:-8]
+        if message[8:12] == UDP_COMMAND:
+            return payload
+        return decrypt(payload, UDP_KEY)
     if message[:4] == PREFIX_6699_BIN:
         unpacked = pytuya.unpack_message(message, hmac_key=UDP_KEY, no_retcode=None)
         payload = unpacked.payload.decode()


### PR DESCRIPTION
1) I have a wifi socket that uses 3.1 tuya API protocol. It sends an unencrypted broadcast message. Without this fix, I can't create a device for my socket and see the following messages in the logs:
```
2024-01-04 19:16:18.227 DEBUG (MainThread) [custom_components.localtuya.discovery] Failed to decode bordcast from '192.168.1.190': b'\x00\x00U\xaa\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x9f\x00\x00\x00\x00{"ip":"192.168.1.190","gwId":"04110747dc4f22865333","active":2,"ability":0,"mode":0,"encrypt":true,"productKey":"********","version":"3.1"}\x7f\xa5\xac\xec\x00\x00\xaaU'
```

2) `Fix climates plaform definitions` commit is a small fix from my previous findings