### PR TITLE
Add option to switch Open/Close commands

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -40,6 +40,7 @@ COVER_COMMANDS = {
     "Open, Close and Stop": "open_close_stop",
     "ON, OFF and Stop": "on_off_stop",
     "fz, zz and Stop": "fz_zz_stop",
+    "zz, fz and Stop": "zz_fz_stop",
     "1, 2 and 3": "1_2_3",
     "0, 1 and 2": "0_1_2",
 }


### PR DESCRIPTION
Fixes an issue where commands are reversed (fz and zz), which causes the buttons in the cover entity to be unusable 