### PR TITLE
Explicit stop of sub-devices heartbeat

### DIFF
--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -948,7 +948,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             """Continuously send heart beat updates."""
             self.debug("Start a heartbeat for sub-devices")
             # This will break if main "heartbeat" stopped
-            while True and self.heartbeater:
+            while True:
                 try:
                     # Reset the state before every reuqest.
                     self.sub_devices_states = {"online": [], "offline": []}
@@ -1002,6 +1002,10 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         """Clean up session."""
         self.debug(f"Cleaning up session.")
         self.real_local_key = self.local_key
+
+        if self.sub_devices_hb:
+            self.sub_devices_hb.cancel()
+
         if self.heartbeater:
             self.heartbeater.cancel()
 


### PR DESCRIPTION
Sub-devices heartbeat loop might be in the `asyncio.sleep(HEARTBEAT_SUB_DEVICES_INTERVAL)`, or perform `subdevices_query()`, while the connection is already lost. Explicit `cancel()` call before other `clean_up_session()` actions resolves this issue.

This change is running in my HA for weeks, experienced a lot of disconnects, and never failed.