### PR TITLE
Don't invalidate sub-devices immediately

### DIFF
--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -505,9 +505,8 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
             return
 
         self._call_on_close.append(asyncio.create_task(self._async_reconnect()).cancel)
-        delay = (0 if self.is_subdevice else 3) + sleep_time
         fun = partial(self._shutdown_entities, exc=exc)
-        self._call_on_close.append(async_call_later(self._hass, delay, fun))
+        self._call_on_close.append(async_call_later(self._hass, 3 + sleep_time, fun))
 
     async def _async_reconnect(self):
         """Task: continuously attempt to reconnect to the device."""


### PR DESCRIPTION
Most of the time, sub-devices receive `disconnected()` due to their gateway has closed the connection. The subsequent reconnect is often instant, so that there is no a real need to call `self._shutdown_entities()`. Since all the async activity was re-implemented in the main thread, this call delays reconnection process. Compare:
<details>
  <summary>Reconnect without delay for _shutdown_entities (709 ms)</summary>
  
  ```
2024-07-09 22:58:44.948 WARNING (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb/G] Disconnected as gateway
2024-07-09 22:58:44.951 INFO (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb] Disconnected
2024-07-09 22:58:44.952 INFO (MainThread) [custom_components.localtuya.coordinator] [bf2...ath - ГСЛ: Zigbee Bulb] Disconnected
2024-07-09 22:58:44.952 INFO (MainThread) [custom_components.localtuya.coordinator] [bfa...hoi - К: 3x Переключатель] Disconnected
2024-07-09 22:58:44.953 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...tdq - ГС: Выключатель] Disconnected
2024-07-09 22:58:44.953 INFO (MainThread) [custom_components.localtuya.coordinator] [bf1...kn4 - ГС: 3x Переключатель] Disconnected
2024-07-09 22:58:44.953 INFO (MainThread) [custom_components.localtuya.coordinator] [bf1...xw5 - К: Выключатель] Disconnected
2024-07-09 22:58:44.953 INFO (MainThread) [custom_components.localtuya.coordinator] [bfb...cbv - К: Реле 4х] Disconnected
2024-07-09 22:58:44.955 INFO (MainThread) [custom_components.localtuya.coordinator] [bfa...dbm - ГСЛ: Реле 4х] Disconnected
2024-07-09 22:58:44.956 INFO (MainThread) [custom_components.localtuya.coordinator] [bf2...aky - ГС: 2х Переключатель] Disconnected
2024-07-09 22:58:44.962 INFO (MainThread) [custom_components.localtuya.coordinator] [bff...ns9 - ПЛ: Диммер] Disconnected
2024-07-09 22:58:44.962 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...epk - П: Выключатель] Disconnected
2024-07-09 22:58:44.969 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...whd - КЛ: Zigbee Bulb] Sub-devices heartbeat stopped
2024-07-09 22:58:45.070 INFO (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb/G] Trying to connect to: 192.168.0.31...
2024-07-09 22:58:45.071 INFO (SyncWorker_3) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.073 INFO (SyncWorker_49) [custom_components.localtuya.coordinator] [bf2...ath - ГСЛ: Zigbee Bulb] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.074 INFO (SyncWorker_49) [custom_components.localtuya.coordinator] [bf0...tdq - ГС: Выключатель] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.074 INFO (SyncWorker_30) [custom_components.localtuya.coordinator] [bfa...hoi - К: 3x Переключатель] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.079 INFO (SyncWorker_30) [custom_components.localtuya.coordinator] [bf1...xw5 - К: Выключатель] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.080 INFO (SyncWorker_44) [custom_components.localtuya.coordinator] [bfa...dbm - ГСЛ: Реле 4х] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.080 INFO (SyncWorker_44) [custom_components.localtuya.coordinator] [bf2...aky - ГС: 2х Переключатель] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.081 INFO (SyncWorker_44) [custom_components.localtuya.coordinator] [bff...ns9 - ПЛ: Диммер] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.081 INFO (SyncWorker_44) [custom_components.localtuya.coordinator] [bf0...epk - П: Выключатель] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.081 INFO (SyncWorker_49) [custom_components.localtuya.coordinator] [bf1...kn4 - ГС: 3x Переключатель] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.082 INFO (SyncWorker_30) [custom_components.localtuya.coordinator] [bfb...cbv - К: Реле 4х] Sub-device disconnected due to: Gateway disconnected
2024-07-09 22:58:45.385 INFO (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb/G] Connected as gateway to: 192.168.0.31
2024-07-09 22:58:45.386 WARNING (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb/G] Sub-devices heartbeat started 192.168.0.31
2024-07-09 22:58:45.428 INFO (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb] Success: connected to: 192.168.0.31
2024-07-09 22:58:45.469 INFO (MainThread) [custom_components.localtuya.coordinator] [bf2...ath - ГСЛ: Zigbee Bulb] Success: connected to: 192.168.0.31
2024-07-09 22:58:45.473 INFO (MainThread) [custom_components.localtuya.coordinator] [bfa...hoi - К: 3x Переключатель] Success: connected to: 192.168.0.31
2024-07-09 22:58:45.476 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...tdq - ГС: Выключатель] Success: connected to: 192.168.0.31
2024-07-09 22:58:45.480 INFO (MainThread) [custom_components.localtuya.coordinator] [bf1...kn4 - ГС: 3x Переключатель] Success: connected to: 192.168.0.31
2024-07-09 22:58:45.538 INFO (MainThread) [custom_components.localtuya.coordinator] [bf1...xw5 - К: Выключатель] Success: connected to: 192.168.0.31
2024-07-09 22:58:45.542 INFO (MainThread) [custom_components.localtuya.coordinator] [bfb...cbv - К: Реле 4х] Success: connected to: 192.168.0.31
2024-07-09 22:58:45.550 INFO (MainThread) [custom_components.localtuya.coordinator] [bfa...dbm - ГСЛ: Реле 4х] Success: connected to: 192.168.0.31
2024-07-09 22:58:45.555 INFO (MainThread) [custom_components.localtuya.coordinator] [bf2...aky - ГС: 2х Переключатель] Success: connected to: 192.168.0.31
2024-07-09 22:58:45.559 INFO (MainThread) [custom_components.localtuya.coordinator] [bff...ns9 - ПЛ: Диммер] Success: connected to: 192.168.0.31
2024-07-09 22:58:45.657 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...epk - П: Выключатель] Success: connected to: 192.168.0.31
  ```
  
</details>
<details>
  <summary>Reconnect with 3s delay for _shutdown_entities (446 ms)</summary>
  
  ```
2024-07-10 08:31:49.613 WARNING (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb/G] Disconnected as gateway
2024-07-10 08:31:49.615 INFO (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb] Disconnected
2024-07-10 08:31:49.616 INFO (MainThread) [custom_components.localtuya.coordinator] [bf2...ath - ГСЛ: Zigbee Bulb] Disconnected
2024-07-10 08:31:49.616 INFO (MainThread) [custom_components.localtuya.coordinator] [bfa...hoi - К: 3x Переключатель] Disconnected
2024-07-10 08:31:49.617 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...tdq - ГС: Выключатель] Disconnected
2024-07-10 08:31:49.617 INFO (MainThread) [custom_components.localtuya.coordinator] [bf1...kn4 - ГС: 3x Переключатель] Disconnected
2024-07-10 08:31:49.617 INFO (MainThread) [custom_components.localtuya.coordinator] [bf1...xw5 - К: Выключатель] Disconnected
2024-07-10 08:31:49.618 INFO (MainThread) [custom_components.localtuya.coordinator] [bfb...cbv - К: Реле 4х] Disconnected
2024-07-10 08:31:49.618 INFO (MainThread) [custom_components.localtuya.coordinator] [bfa...dbm - ГСЛ: Реле 4х] Disconnected
2024-07-10 08:31:49.618 INFO (MainThread) [custom_components.localtuya.coordinator] [bf2...aky - ГС: 2х Переключатель] Disconnected
2024-07-10 08:31:49.618 INFO (MainThread) [custom_components.localtuya.coordinator] [bff...ns9 - ПЛ: Диммер] Disconnected
2024-07-10 08:31:49.619 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...epk - П: Выключатель] Disconnected
2024-07-10 08:31:49.639 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...whd - КЛ: Zigbee Bulb] Sub-devices heartbeat stopped
2024-07-10 08:31:49.643 INFO (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb/G] Trying to connect to: 192.168.0.31...
2024-07-10 08:31:49.896 INFO (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb/G] Connected as gateway to: 192.168.0.31
2024-07-10 08:31:49.897 WARNING (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb/G] Sub-devices heartbeat started 192.168.0.31
2024-07-10 08:31:49.938 INFO (MainThread) [custom_components.localtuya.coordinator] [bf5...whd - КЛ: Zigbee Bulb] Success: connected to: 192.168.0.31
2024-07-10 08:31:49.941 INFO (MainThread) [custom_components.localtuya.coordinator] [bf2...ath - ГСЛ: Zigbee Bulb] Success: connected to: 192.168.0.31
2024-07-10 08:31:49.951 INFO (MainThread) [custom_components.localtuya.coordinator] [bfa...hoi - К: 3x Переключатель] Success: connected to: 192.168.0.31
2024-07-10 08:31:50.022 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...tdq - ГС: Выключатель] Success: connected to: 192.168.0.31
2024-07-10 08:31:50.025 INFO (MainThread) [custom_components.localtuya.coordinator] [bf1...kn4 - ГС: 3x Переключатель] Success: connected to: 192.168.0.31
2024-07-10 08:31:50.028 INFO (MainThread) [custom_components.localtuya.coordinator] [bf1...xw5 - К: Выключатель] Success: connected to: 192.168.0.31
2024-07-10 08:31:50.035 INFO (MainThread) [custom_components.localtuya.coordinator] [bfb...cbv - К: Реле 4х] Success: connected to: 192.168.0.31
2024-07-10 08:31:50.038 INFO (MainThread) [custom_components.localtuya.coordinator] [bfa...dbm - ГСЛ: Реле 4х] Success: connected to: 192.168.0.31
2024-07-10 08:31:50.041 INFO (MainThread) [custom_components.localtuya.coordinator] [bf2...aky - ГС: 2х Переключатель] Success: connected to: 192.168.0.31
2024-07-10 08:31:50.056 INFO (MainThread) [custom_components.localtuya.coordinator] [bff...ns9 - ПЛ: Диммер] Success: connected to: 192.168.0.31
2024-07-10 08:31:50.059 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...epk - П: Выключатель] Success: connected to: 192.168.0.31
  ```
  
</details>
</details>

The logs were taken for my Ethernet gateway that closes connections when its CPU is overloaded due to some sensors send data almost at the same time. The 2nd log was taken during HA/LocalTuya startup process, when LocalTuya also was busy with first time connections to other devices, but I've removed those records. Here they are:

<details>
  <summary>Records, removed from the 2nd log</summary>
  
  ```
2024-07-10 08:31:49.641 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...sti - ГЛ2: LED BULB W5K] Success: connected to: 192.168.0.43
2024-07-10 08:31:49.656 INFO (MainThread) [custom_components.localtuya.coordinator] [bf1...sa9 - ВС: Питание HA] Success: connected to: 192.168.0.52
2024-07-10 08:31:49.695 INFO (MainThread) [custom_components.localtuya.coordinator] [bf8...m91 - К: T&H Сенсор/G] Connected as gateway to: 192.168.0.33
2024-07-10 08:31:49.696 WARNING (MainThread) [custom_components.localtuya.coordinator] [bf8...m91 - К: T&H Сенсор/G] Sub-devices heartbeat started 192.168.0.33
2024-07-10 08:31:49.727 INFO (MainThread) [custom_components.localtuya.coordinator] [bff...hco - ВС: Выключатель] Success: connected to: 192.168.0.32
2024-07-10 08:31:49.732 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...f1a - ВС: T&H Сенсор] Success: connected to: 192.168.0.32
2024-07-10 08:31:49.735 INFO (MainThread) [custom_components.localtuya.coordinator] [bf4...huv - ВС: Zigbee Bulb] Success: connected to: 192.168.0.32
2024-07-10 08:31:49.737 INFO (MainThread) [custom_components.localtuya.coordinator] [bfe...edr - ВС: Реле 4х] Success: connected to: 192.168.0.32
2024-07-10 08:31:49.772 INFO (MainThread) [custom_components.localtuya.coordinator] [bf4...l4c - ВЛ1: Beacon RGBCW] Success: connected to: 192.168.0.32
2024-07-10 08:31:49.787 INFO (MainThread) [custom_components.localtuya.coordinator] [bf4...sqd - ВЛ2: Beacon RGBCW] Success: connected to: 192.168.0.32
2024-07-10 08:31:49.790 INFO (MainThread) [custom_components.localtuya.coordinator] [bf1...ibq - ВС: Чёрная кнопка] Success: connected to: 192.168.0.32
2024-07-10 08:31:49.794 INFO (MainThread) [custom_components.localtuya.coordinator] [bf6...ytx - ВЛ3: Beacon RGBCW] Success: connected to: 192.168.0.32
2024-07-10 08:31:49.826 INFO (MainThread) [custom_components.localtuya.coordinator] [bf0...vcr - ВС: USB Smart Adapter] Success: connected to: 192.168.0.53
2024-07-10 08:31:49.970 INFO (MainThread) [custom_components.localtuya.coordinator] [bf8...m91 - К: T&H Сенсор] Success: connected to: 192.168.0.33
2024-07-10 08:31:49.973 INFO (MainThread) [custom_components.localtuya.coordinator] [bf5...daj - КЛ1: LED BULB B5K] Success: connected to: 192.168.0.33
2024-07-10 08:31:49.977 INFO (MainThread) [custom_components.localtuya.coordinator] [bff...mj7 - КЛ2: LED BULB B5K] Success: connected to: 192.168.0.33
2024-07-10 08:31:49.982 INFO (MainThread) [custom_components.localtuya.coordinator] [bff...jl9 - КЛ3: LED BULB B5K] Success: connected to: 192.168.0.33
  ```
  
</details>

They are WiFi bulbs and sub-devices of other gateways.

But the first log is provided as is. In real life, reconnect to this gateway takes around 300 ms, even with more devices at this gateway in the past, i.e. more than twice faster than with `_shutdown_entities` calls. You see now how heavy this call is! Well, not the call by itself, but along with related tasks to switch contexts and serve the task queue.

FIY, I have 3 gateways, and I experienced often disconnects every day. For two WiFi gateways, I've traced the problem down to weak WiFi signal. Since I've moved one of them to a better place, it stopped disconnecting. I can't move the second WiFi gateway. With the 3rd, Ethernet gateway, I traced the problem down to its CPU overload. Since I moved some sensors from it to a Zigbee LAN coordinator under Zigbee2MQTT control, the disconnects happen much less often.

The HA host is an armbianed TV box with Amlogic S905X3 SoC and 4GB of RAM, with average CPU load under 6%. So, it is not the weakest host that people use for HA, and my experience is good to consider 😄 

Please do not think for this part of functionality about sub-devices that went offline: after my investigation of this case, which was found unrelated, next follow another pull request.