### PR TITLE
Refactor Sub-Devices reconnecting task

### DIFF
--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -541,7 +541,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 break
 
             if self.connected:
-                if not self.is_sleep and attempts > 0
+                if not self.is_sleep and attempts > 0:
                     self.info(f"Reconnect succeeded on attempt: {attempts}")
                 break
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -540,7 +540,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 self.debug(f"Reconnect task has been canceled: {e}", force=True)
                 break
 
-            if self.connected:
+            if self.connected and not self.is_sleep and attempts > 0:
                 self.debug(f"Reconnect succeeded on attempt: {attempts}", force=True)
                 break
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -540,8 +540,9 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 self.debug(f"Reconnect task has been canceled: {e}", force=True)
                 break
 
-            if self.connected and not self.is_sleep and attempts > 0:
-                self.debug(f"Reconnect succeeded on attempt: {attempts}", force=True)
+            if self.connected:
+                if not self.is_sleep and attempts > 0
+                    self.info(f"Reconnect succeeded on attempt: {attempts}")
                 break
 
             attempts += 1

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -80,6 +80,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         self._connect_task: asyncio.Task | None = None
         self._unsub_refresh: CALLBACK_TYPE | None = None
         self._reconnect_task = False
+        self._online = True
         self._call_on_close: list[CALLBACK_TYPE] = []
         self._entities = []
         self._local_key: str = self._device_config.local_key
@@ -541,3 +542,15 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
             await asyncio.sleep(RECONNECT_INTERVAL.total_seconds())
 
         self._reconnect_task = False
+
+    @callback
+    def online(self, is_online):
+        """Device is offline or online."""
+        if is_online == self._online:
+            return
+
+        self._online = is_online
+        self.warning("Sub-device is " + ("online" if is_online else "offline"))
+# It has no sense to disconnect when sub-device went offline!
+#        if not is_online:
+#            self.disconnected("Device is offline")

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -554,7 +554,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
     def subdevice_state(self, is_online):
         """Sub-Device is offline or online."""
         off_count = self._subdevice_off_count
-        self._subdevice_off_count = 0 if is_online else off_count  + 1
+        self._subdevice_off_count = 0 if is_online else off_count + 1
 
         if is_online:
             return self.info("Sub-device is online") if off_count > 0 else None

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -554,8 +554,8 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         """Device is offline or online."""
         if is_online:
             if self._offline > 0:
-                self.warning("Sub-device is online")
                 self._offline = 0
+                self.warning("Sub-device is online")
         else:
             self._offline += 1
             if self._offline == MIN_OFFLINE_EVENTS:

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -521,7 +521,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         while True and not self._is_closing:
             # for sub-devices, if it is reported as offline then no need for reconnect.
             if self.is_subdevice and self._offline >= MIN_OFFLINE_EVENTS:
-                await asyncio.sleep(10)
+                await asyncio.sleep(1)
                 continue
 
             # for sub-devices, if the gateway isn't connected then no need for reconnect.

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -532,10 +532,10 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 continue
 
             try:
+                if not self._connect_task:
+                    await self.async_connect()
                 if self._connect_task:
                     await self._connect_task
-                else:
-                    await self.async_connect()
             except asyncio.CancelledError as e:
                 self.debug(f"Reconnect task has been canceled: {e}", force=True)
                 break

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -551,7 +551,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         self._reconnect_task = False
 
     @callback
-    def online(self, is_online):
+    def subdevice_state(self, is_online):
         """Sub-Device is offline or online."""
         off_count = self._subdevice_off_count
         self._subdevice_off_count = 0 if is_online else off_count  + 1

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -552,14 +552,15 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
     @callback
     def online(self, is_online):
-        """Device is offline or online."""
+        """Sub-Device is offline or online."""
+        off_count = self._offline
+        self._offline = 0 if is_online else off_count  + 1
+
         if is_online:
-            if self._offline > 0:
-                self._offline = 0
-                self.warning("Sub-device is online")
+            return self.info("Sub-device is online") if off_count > 0 else None
         else:
-            self._offline += 1
-            if self._offline == 1:
+            off_count += 1
+            if off_count == 1:
                 self.warning("Sub-device is offline")
-            elif self._offline == MIN_OFFLINE_EVENTS:
+            elif off_count >= MIN_OFFLINE_EVENTS:
                 self.disconnected("Device is offline")

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -558,6 +558,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 self.warning("Sub-device is online")
         else:
             self._offline += 1
-            if self._offline == MIN_OFFLINE_EVENTS:
+            if self._offline == 1:
                 self.warning("Sub-device is offline")
+            elif self._offline == MIN_OFFLINE_EVENTS:
                 self.disconnected("Device is offline")

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -735,6 +735,10 @@ class TuyaListener(ABC):
     def disconnected(self, exc=""):
         """Device disconnected."""
 
+    @abstractmethod
+    def online(self, is_online):
+        """Device is offline or online."""
+
 
 class EmptyListener(TuyaListener):
     """Listener doing nothing."""
@@ -744,6 +748,9 @@ class EmptyListener(TuyaListener):
 
     def disconnected(self, exc=""):
         """Device disconnected."""
+
+    def online(self, is_online):
+        """Device is offline or online."""
 
 
 class TuyaProtocol(asyncio.Protocol, ContextualLogger):
@@ -846,9 +853,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 if listener is None or on_devs is None:
                     return
                 for cid, device in listener.sub_devices.items():
-                    if cid not in on_devs:
-                        self.debug(f"Sub-device disconnected: {cid}")
-                        device.disconnected("Device is offline")
+                    device.online(cid in on_devs)
             except asyncio.CancelledError:
                 pass
 

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -736,7 +736,7 @@ class TuyaListener(ABC):
         """Device disconnected."""
 
     @abstractmethod
-    def online(self, is_online):
+    def subdevice_state(self, is_online):
         """Device is offline or online."""
 
 
@@ -749,7 +749,7 @@ class EmptyListener(TuyaListener):
     def disconnected(self, exc=""):
         """Device disconnected."""
 
-    def online(self, is_online):
+    def subdevice_state(self, is_online):
         """Device is offline or online."""
 
 
@@ -853,7 +853,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 if listener is None or on_devs is None:
                     return
                 for cid, device in listener.sub_devices.items():
-                    device.online(cid in on_devs)
+                    device.subdevice_state(cid in on_devs)
             except asyncio.CancelledError:
                 pass
 


### PR DESCRIPTION
A connection for a sub-device is a connection to its gateway. No one of my gateways produce an error on request status or sending a command from/to offline sub-device. They silently accept commands and return cached status for hours. So, there is no a need to call `disconnected()` for a device that went offline: it just reconnects instantly, I didn't even see "unavailable" state for a moment in HA UI in tests with now commented out `disconnected()` call. Here is a log of such event:

<details>
  <summary>Disconnect of offline device</summary>
  
  ```
2024-07-09 20:54:44.561 WARNING (MainThread) [custom_components.localtuya.coordinator] [bff...ns9 - ПЛ: Диммер] Sub-device is offline
2024-07-09 20:54:44.567 INFO (MainThread) [custom_components.localtuya.coordinator] [bff...ns9 - ПЛ: Диммер] Disconnected
2024-07-09 20:54:44.662 INFO (SyncWorker_57) [custom_components.localtuya.coordinator] [bff...ns9 - ПЛ: Диммер] Sub-device disconnected due to: Device is offline
2024-07-09 20:54:44.703 INFO (MainThread) [custom_components.localtuya.coordinator] [bff...ns9 - ПЛ: Диммер] Success: connected to: 192.168.0.31
2024-07-09 20:56:14.610 WARNING (MainThread) [custom_components.localtuya.coordinator] [bff...ns9 - ПЛ: Диммер] Sub-device is online
  ```
  
</details>

It would be even faster if not a call to `self._shutdown_entities()` (https://github.com/xZetsubou/hass-localtuya/pull/304). I ran tests for several hours with a dimmer (constantly powered) and a scene switch (battery powered). With the dimmer, LocalTuya notified me in 30 seconds while Tuya cloud notified in 30 minutes. With the scene switch, both notified at the same time, exactly after 12 hours of removing the battery.

So, from my point of view, this functionality is only good for early notification about a powered sub-device with weak signal. It means, it shall produce either a warning or an error, to be visible for all the users without additional efforts.

But the current implementation just creates disconnect-reconnect loop every 30 seconds. If I convert its debug message to a warning, it bugs me every 30 seconds with the same information, and there is no a way to be notified that the sub-device has returned to online state.

I see you have just submitted a [commit](https://github.com/Lurker00/hass-localtuya/commit/a34e316448b5dd1762afee5b0c696016c5d756d9) to stop connecting of offline sub-device. This is _not_ a good solution: from my experience, a sub-device may go offline for a second, but your solution would not use it for up to 30 seconds (`HEARTBEAT_SUB_DEVICES_INTERVAL`) + 10 seconds of waiting in that loop. I have a number of devices with weak signals (relays, that dimmer), I'm notified, but they always work when required with both LocalTuya and SmartLife automations. With your solution, they won't work with LocalTuya time to time.