### PR TITLE
Keep None values for all DP's of write-only BLE bulbs.

### DIFF
--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -190,8 +190,11 @@ class LocalTuyaLight(LocalTuyaEntity, LightEntity):
 
             if not custom_scenes:
                 self._scenes = {**EFFECTS_MODES, **self._scenes}
+        elif self._write_only and self._config.get(CONF_COLOR_MODE):
+            self._scenes = EFFECTS_MODES
 
-            self._effect_list = list(self._scenes.keys())
+        self._effect_list = list(self._scenes.keys())
+
         if self._config.get(CONF_MUSIC_MODE):
             self._effect_list.append(SCENE_MUSIC)
 


### PR DESCRIPTION
A bulb is an active (mains powered) device, and is expected to respond on requests. But I have BLE bulbs which never neither report their status nor reply on requests. Their DP's are, actually, write-only. To add such a bulb to LocalTuya, I put 0 to Manual DP's list, and then it can be controlled from HA automation and UI.

SmartLife provides full control, but does not show the current state. Meaning, SmartLife ignores bulb status update from the BLE gateway for such devices. The same behavior is expected from HA/LocalTuya.

I've found out that if I combine such bulbs into a group in SmartLife, the BLE gateway which controls the group, notifies about status changes for the first bulb in the group. These notifications change the state of DPs in LocalTuya and then are reflected in HA UI. But these values can't be trusted: if the state of the bulb was changed by other means (commands sent individually, or by a physical switch), nobody knows about such changes.

The current Light implementation in LocalTuya relies on the bulb state at least here:
https://github.com/xZetsubou/hass-localtuya/blob/a34e316448b5dd1762afee5b0c696016c5d756d9/custom_components/localtuya/light.py#L360-L361
which prevents turning the bulb on if it was turned off individually. I use one of the bulbs in a chandelier as a night light and faced this problem.

The fix detects that the bulb is write-only, and then prevents any its DP change, and reports `None` for them.