### PR TITLE
Eliminate no delay writes

### DIFF
--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -228,7 +228,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
                 self.debug("Retrieving initial state")
                 # Usually we use status instead of detect_available_dps, but some device doesn't reports all dps when ask for status.
-                status = await self._interface.status(self._node_id)
+                status = await self._interface.status(cid=self._node_id)
                 if status is None:
                     raise Exception("Failed to retrieve status")
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -228,7 +228,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
                 self.debug("Retrieving initial state")
                 # Usually we use status instead of detect_available_dps, but some device doesn't reports all dps when ask for status.
-                status = await self._interface.status(cid=self._node_id)
+                status = await self._interface.status(self._node_id)
                 if status is None:
                     raise Exception("Failed to retrieve status")
 

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -750,8 +750,6 @@ class EmptyListener(TuyaListener):
 class TuyaProtocol(asyncio.Protocol, ContextualLogger):
     """Implementation of the Tuya protocol."""
 
-    HEARTBEAT_SKIP = 5
-
     def __init__(
         self,
         dev_id: str,
@@ -925,9 +923,8 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             self.debug("Started heartbeat loop")
             while True:
                 try:
-                    # if self.last_command_sent > self.HEARTBEAT_SKIP:
-                    await self.heartbeat()
                     await asyncio.sleep(HEARTBEAT_INTERVAL)
+                    await self.heartbeat()
                 except asyncio.CancelledError:
                     self.debug("Stopped heartbeat loop")
                     raise

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -987,7 +987,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         """Write data on transport, ensure that no massive requests happen all at once."""
         wait = 0
         while self.last_command_sent < 0.050:
-            await asyncio.sleep(0.060)
+            await asyncio.sleep(0.010)
             wait += 1
             if wait >= 10:
                 break

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -726,7 +726,6 @@ class TuyaListener(ABC):
     """Listener interface for Tuya device changes."""
 
     sub_devices: dict[str, Self]
-    sub_device_online = False
 
     @abstractmethod
     def status_updated(self, status):

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -1202,7 +1202,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             # in the requested range
             self.dps_to_request = {"1": None}
             self.add_dps_to_request(range(*dps_range))
-            data = await self.status(cid, delay)
+            data = await self.status(cid=cid, delay=delay)
             if cid and cid in data:
                 self.dps_cache.update({cid: data[cid]})
             elif not cid and "parent" in data:

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -950,10 +950,10 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             self.debug("Start a heartbeat for sub-devices")
             while True:
                 try:
+                    await asyncio.sleep(HEARTBEAT_SUB_DEVICES_INTERVAL)
                     # Reset the state before every request.
                     self.sub_devices_states = {"online": [], "offline": []}
                     await self.subdevices_query()
-                    await asyncio.sleep(HEARTBEAT_SUB_DEVICES_INTERVAL)
                 except asyncio.CancelledError:
                     break
                 except Exception as ex:

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -1111,7 +1111,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             return await self.exchange(command, dps, nodeID=nodeID)
         return payload
 
-    async def status(self, cid):
+    async def status(self, cid=None):
         """Return device status."""
         status: dict = await self.exchange(command=DP_QUERY, nodeID=cid)
 


### PR DESCRIPTION
After reading [your comment](https://github.com/xZetsubou/hass-localtuya/commit/a76f58ac948807e15f3b715de5147b583debf8bb#r144108583), I've analyzed the source code and found out, that:
- `transport_write()` without a delay is called only from `exchange()`.
- `exchange()` without a delay is called only from `status()`, always.
- `status()` is called only in two places:
https://github.com/xZetsubou/hass-localtuya/blob/a34e316448b5dd1762afee5b0c696016c5d756d9/custom_components/localtuya/coordinator.py#L231
https://github.com/xZetsubou/hass-localtuya/blob/a34e316448b5dd1762afee5b0c696016c5d756d9/custom_components/localtuya/core/pytuya/__init__.py#L1207

I can understand a need for sending requests without a delay only in the case of subsequent requests with no delay between them. So, I'm confident that the first call can be performed with the delay. Moreover, it is exactly the call that caused [me problems](https://github.com/xZetsubou/hass-localtuya/commit/a76f58ac948807e15f3b715de5147b583debf8bb#r144097787).

I don't quite understand if the second call to `status()` (several calls in the loop, actually) may need to have no delays in between. I doubt it. But I'm confident that the first write can be done without a delay. So, I introduced `delay` parameter to `status()`, and now it can be `False` only being called from `detect_available_dps()`. But I'd prefer to delete `command_delay` parameter from `transport_write()` as not actually used and as dangerous.

Forgetting about `detect_available_dps()`, now I'm confident that the heartbeat does not require additional synchronization before sending requests. But I delayed the first heartbeat to let LocalTuya start faster and smoother.

The 3rd commit (d1b07dbf482f01517be771f35818db9d18163205) reverted traces of my experiment to ensure that `status()` is called only in two places: I've removed default parameters values to let python compiler to catch other calls, if any.

**In brief:**
- The 1st commit (d2bf8cef08a931d1ac7ffb39c62f070cbec1a534) _almost_ fixes [my problem](https://github.com/xZetsubou/hass-localtuya/commit/a76f58ac948807e15f3b715de5147b583debf8bb#r144097787). I'm sure this line order is good anyway.
- The 2nd commit (af1a73a897b0616aae02212037a84336db761268) fixes [my problem](https://github.com/xZetsubou/hass-localtuya/commit/a76f58ac948807e15f3b715de5147b583debf8bb#r144097787) and reduces the chance of a similar problem in case of (rare?) user setup when `detect_available_dps()` is called periodically.
- I prefer to eliminate `command_delay` parameter from `transport_write()` and then revert my second commit.