### PR TITLE
Refactor of making connections

### DIFF
--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -69,7 +69,6 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         self._fake_gateway = fake_gateway
         self._gateway: TuyaDevice = None
         self.sub_devices: dict[str, TuyaDevice] = {}
-        self.sub_device_online = True
 
         self._status = {}
         # Sleep timer, a device that reports the status every x seconds then goes into sleep.
@@ -526,10 +525,6 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 continue
 
             # for sub-devices, if the gateway isn't connected then no need for reconnect.
-            if self.is_subdevice and not self.sub_device_online:
-                self.warning(f"Sub deivce is offline")
-                await asyncio.sleep(10)
-                continue
             if self._gateway and (
                 not self._gateway.connected or self._gateway.is_connecting
             ):

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -563,10 +563,10 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         self._subdevice_off_count = 0 if is_online else off_count + 1
 
         if is_online:
-            return self.info("Sub-device is online") if off_count > 0 else None
+            return self.info(f"Sub-device is online {self._node_id}") if off_count > 0 else None
         else:
             off_count += 1
             if off_count == 1:
-                self.warning("Sub-device is offline")
+                self.warning(f"Sub-device is offline {self._node_id}")
             elif off_count >= MIN_OFFLINE_EVENTS:
                 self.disconnected("Device is offline")

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -950,7 +950,10 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         if self.heartbeater is None:
             # Prevent duplicates heartbeat task
             self.heartbeater = self.loop.create_task(
-                heartbeat_loop(sq if is_gateway else hb)
+                heartbeat_loop(
+                    # Ver. 3.3 gateways don't respond to subdevice query
+                    sq if is_gateway and self.version >= 3.4 else hb
+                )
             )
 
     def data_received(self, data):

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -181,7 +181,7 @@ NO_PROTOCOL_HEADER_CMDS = [
     LAN_EXT_STREAM,
 ]
 
-HEARTBEAT_INTERVAL = 10
+HEARTBEAT_INTERVAL = 9
 
 # DPS that are known to be safe to use with update_dps (0x12) command
 UPDATE_DPS_WHITELIST = [18, 19, 20]  # Socket (Wi-Fi)

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -797,7 +797,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         self.dispatcher = self._setup_dispatcher()
         self.on_connected = on_connected
         self.heartbeater: asyncio.Task | None = None
-        self.sub_devices_hb: asyncio.Task | None = None
         self._sub_devs_query_task: asyncio.Task | None = None
         self.dps_cache = {}
         self.sub_devices_states = {"online": [], "offline": []}
@@ -993,9 +992,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         """Clean up session."""
         self.debug(f"Cleaning up session.")
         self.real_local_key = self.local_key
-
-        if self.sub_devices_hb:
-            self.sub_devices_hb.cancel()
 
         if self.heartbeater:
             self.heartbeater.cancel()

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -927,7 +927,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                     await action()
                 except asyncio.CancelledError:
                     self.debug("Stopped heartbeat loop")
-                    raise
+                    break
                 except asyncio.TimeoutError:
                     self.debug("Heartbeat failed due to timeout, disconnecting")
                     break

--- a/custom_components/localtuya/discovery.py
+++ b/custom_components/localtuya/discovery.py
@@ -97,7 +97,7 @@ class TuyaDiscovery(asyncio.DatagramProtocol):
             self.device_found(decoded)
         except:
             # _LOGGER.debug("Bordcast from app from ip: %s", addr[0])
-            _LOGGER.debug("Failed to decode bordcast from %r: %r", addr[0], data)
+            _LOGGER.debug("Failed to decode broadcast from %r: %r", addr[0], data)
 
     def device_found(self, device):
         """Discover a new device."""


### PR DESCRIPTION
This pull request works better with [312](https://github.com/xZetsubou/hass-localtuya/pull/312), though it does not depend on it.

I intentionally made several commits, because most of them are not related to the main goal (which is 3b168dab6606bf3f04e3e1534f2367570baac8da). I'd suggest to read commit by commit, for easy understanding.

**Explanations:**

(e50ce752ad62065cf234e90bd7afbfc7a50817bf) I found it useful to tell messages produced by a fake gateway from messages produced by the same sub-device.

Heartbeat as itself is not required: a device closes inactive connection if there is no _any_ activity for some seconds. But having both heartbeat and sub-devices heartbeat provides additional load onto a gateway. I've made only one heartbeat, with the actual activity depending on whether it is a (fake) gateway or a standalone device.

Currently, when a (fake) gateway adds tasks to connect to its sub-devices, the tasks are performed in random order. This may lead to well-known problem causing `"listener exists for {seqno}"` message. Connecting sub-devices one by one does not increase the whole connection time, or increases not significantly, because the overall time is mostly limited by delays in `transport_write`. It also decreases the load on gateways. My 30+ devices with 3 gateways are all connected for less than 2 seconds before and after this change. But, since I've implemeted this, I never saw neither `"listener exists for {seqno}"` , nor events when a gateway drops the connection during connecting to its sub-devices.

(6566305fb092927d26f0493434eb01aec970d3d5) The inactivity timeout depends on the device itself. [Tuya mentions 10 seconds](https://developer.tuya.com/en/docs/iot-device-dev/tuyaos-gateway-heartbeat?id=Kc323jq0g6l2p) as a timeout for gateways when they ping active sub-devices, with a note that this timeout can be configured. But my experience allows to presume that there are devices with 10 seconds inactivity timeout: my wired gateway was closing the connection at nights, at least once every night. My explanation is: having 12 WiFi/Ethernet devices and heartbeat period set to 10 seconds, without any other activity, sometimes the next heartbeat is delayed enough to trigger the gateway's timeout. Decreasing the period to 9 seconds (actually, I tested 9.5 seconds) ensures no inactivity events. Since then, 3 whole days without a disconnect from this gateway.

(dc5e07fcd8c7d4c8b748e76e45b2b6194f289bde) The `heartbeat_loop` is called from an async task, so nobody would gracefuly handle exceptions raised by it.