### PR TITLE
Bug fix: status from a sub-device goes to its gateway

### DIFF
--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -827,7 +827,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         try:
             spayload = json.dumps(payload)
             # spayload = payload.replace('\"','').replace('\'','')
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             spayload = '""'
 
         vals = (error_codes[number], str(number), spayload)
@@ -1031,7 +1031,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
         try:
             await self.transport_write(enc_payload)
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             await self.close()
             return None
         while recv_retries:
@@ -1040,7 +1040,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 msg = await self.dispatcher.wait_for(seqno, payload.cmd)
                 # for 3.4 devices, we get the starting seqno with the SESS_KEY_NEG_RESP message
                 self.seqno = msg.seqno
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 msg = None
             if msg and len(msg.payload) != 0:
                 return msg

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -904,7 +904,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 if cid:
                     # Don't pass sub-device's payload to the (fake)gateway!
                     if not (listener := listener.sub_devices.get(cid, None)):
-                        return self.debug(f"Payload for missing sub-device discarded: \"{decoded_message}\"")
+                        return self.debug(
+                            f'Payload for missing sub-device discarded: "{decoded_message}"'
+                        )
                     status = self.dps_cache.get(cid, {})
                 else:
                     status = self.dps_cache.get("parent", {})

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -903,15 +903,13 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             if listener is not None:
                 if cid:
                     # Don't pass sub-device's payload to the (fake)gateway!
-                    listener = listener.sub_devices.get(cid, None)
+                    if not listener := listener.sub_devices.get(cid, None):
+                        return self.debug(f"Payload for missing sub-device discarded: \"{decoded_message}\"")
                     status = self.dps_cache.get(cid, {})
                 else:
                     status = self.dps_cache.get("parent", {})
 
-                if listener is not None:
-                    listener.status_updated(status)
-                else:
-                    self.debug(f"Payload for missing sub-device discarded: \"{decoded_message}\"")
+                listener.status_updated(status)
 
         return MessageDispatcher(self.id, _status_update, self.version, self.local_key)
 

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -1086,7 +1086,10 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
         enc_payload = self._encode_message(payload)
 
-        await self.transport_write(enc_payload)
+        try:
+            await self.transport_write(enc_payload)
+        except Exception:  # pylint: disable=broad-except
+            return self.clean_up_session()
         msg = await self.dispatcher.wait_for(seqno, payload.cmd)
         if msg is None:
             self.debug("Wait was aborted for seqno %d", seqno)

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -911,7 +911,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 if listener is not None:
                     listener.status_updated(status)
                 else:
-                    self.info(f"Payload for missing sub-device discarded: \"{decoded_message}\"")
+                    self.debug(f"Payload for missing sub-device discarded: \"{decoded_message}\"")
 
         return MessageDispatcher(self.id, _status_update, self.version, self.local_key)
 

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -903,7 +903,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             if listener is not None:
                 if cid:
                     # Don't pass sub-device's payload to the (fake)gateway!
-                    if not listener := listener.sub_devices.get(cid, None):
+                    if not (listener := listener.sub_devices.get(cid, None)):
                         return self.debug(f"Payload for missing sub-device discarded: \"{decoded_message}\"")
                     status = self.dps_cache.get(cid, {})
                 else:

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -867,10 +867,10 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             updated_states["online"] = list(set(cached_on_devs + on_devs))
             updated_states["offline"] = list(set(cached_off_devs + off_devs))
 
-            self.sub_devices_states = updated_states
-
             if self._sub_devs_query_task is not None:
                 self._sub_devs_query_task.cancel()
+
+            self.sub_devices_states = updated_states
             self._sub_devs_query_task = self.loop.create_task(_action())
 
     def _setup_dispatcher(self) -> MessageDispatcher:


### PR DESCRIPTION
The last commit (2e2885042b16b8e17bfc95355b41850d70a9e80a) fixes a bug: a status from payload of a sub-device can be passed to its gateway. Though it is not a problem with fake gateways, which don't accept status changes, it's a big problem with real gateways. The examples are:
- a sub-device is attached to the gateway but not to LocalTuya;
- a sub-device is not added to the gateway's `sub_devices` list when the gateway is already connected (e.g. during LocalTuya current version start).

Tested in both cases, with BLE and ZIgbee sub-devices.

This is the last problem I found that prevented me to use real gateways in LocalTuya. Now I prefer and I'd recommend to add real gateways to LocalTuya, especially to those who has BLE devices.

By the way, I added some other small changes:
- comments for pylint (1bc069a5924f9e95846fafc16e58884f11d39f96);
- a fix for rare case, when the data used by an async task could be changed (21af3e1bfd8be69b0a217b304ecd01c27e526dbb);
- a fix for the case when an error happens during write from `exchange()`(7b0950fca948f421f66001129e92ce0918533509), which is expected to return a value in most calls.
