### PR TITLE
Handling removed/returned subdevices

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -329,7 +329,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             if check_if_device_disabled(hass, entry, dev_id):
                 continue
             if config.get(CONF_NODE_ID):
-                continue # skip sub-devices
+                continue  # skip sub-devices
 
             entities = entry.data[CONF_DEVICES][dev_id][CONF_ENTITIES]
             platforms = platforms.union(
@@ -346,7 +346,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             if check_if_device_disabled(hass, entry, dev_id):
                 continue
             if not (node_id := config.get(CONF_NODE_ID)):
-                continue # skip not sub-devices
+                continue  # skip not sub-devices
 
             entities = entry.data[CONF_DEVICES][dev_id][CONF_ENTITIES]
             platforms = platforms.union(
@@ -376,8 +376,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         # Connect to Tuya devices. Sub-devices will be connected by their gateways.
         connect_to_devices = [
-            asyncio.create_task(device.async_connect())
-            for device in devices_to_connect
+            asyncio.create_task(device.async_connect()) for device in devices_to_connect
         ]
         # Update listener: add to unsub_listeners
         entry_update = entry.add_update_listener(update_listener)

--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -363,7 +363,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
             host = f"{host}_{node_id}"
             devices[host] = (device := TuyaDevice(hass, entry, config))
+            # Add even absent sub-devices, to start connecting with them
             gateway.sub_devices[node_id] = device
+            # Required for an absent device as well, even if it is not its gateway anymore
+            device._gateway = gateway
 
         hass_localtuya = HassLocalTuyaData(tuya_api, devices, [])
         hass.data[DOMAIN][entry.entry_id] = hass_localtuya

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -36,6 +36,7 @@ from .core.pytuya import (
     HEARTBEAT_INTERVAL,
     TuyaListener,
     ContextualLogger,
+    SubdeviceState,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -594,7 +595,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
     @callback
     def subdevice_state(self, state):
         """Sub-Device is offline or online."""
-        if state is TuyaListener.SubdeviceState.ABSENT:
+        if state is SubdeviceState.ABSENT:
             if not self._subdevice_absent:
                 # Don't disconnect immediately, because false events
                 # happen with some gateways!
@@ -610,7 +611,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             self.info(f"Sub-device is back {self._node_id}")
             self._subdevice_absent = False
 
-        is_online = state is TuyaListener.SubdeviceState.ONLINE
+        is_online = state is SubdeviceState.ONLINE
         off_count = self._subdevice_off_count
         self._subdevice_off_count = 0 if is_online else off_count + 1
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -595,7 +595,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
     @callback
     def subdevice_state(self, state):
         """Sub-Device is offline or online."""
-        if state is SubdeviceState.ABSENT:
+        if state == SubdeviceState.ABSENT:
             if not self._subdevice_absent:
                 # Don't disconnect immediately, because false events
                 # happen with some gateways!
@@ -611,7 +611,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             self.info(f"Sub-device is back {self._node_id}")
             self._subdevice_absent = False
 
-        is_online = state is SubdeviceState.ONLINE
+        is_online = state == SubdeviceState.ONLINE
         off_count = self._subdevice_off_count
         self._subdevice_off_count = 0 if is_online else off_count + 1
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -41,7 +41,7 @@ from .core.pytuya import (
 
 _LOGGER = logging.getLogger(__name__)
 RECONNECT_INTERVAL = timedelta(seconds=5)
-# Offline events before disconnecting the device, around 5 minutes
+# Subdevice: Offline events before disconnecting the device, around 5 minutes
 MIN_OFFLINE_EVENTS = 5 * 60 // HEARTBEAT_INTERVAL
 
 
@@ -165,7 +165,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         """Return the gateway device of this sub device."""
         if not self._node_id:
             return None  # Should never happen
-        if (gateway := self._gateway) == None:
+        if (gateway := self._gateway) is None:
             return None  # Should never happen
 
         # Ensure that sub-device still on the same gateway device.

--- a/custom_components/localtuya/core/cloud_api.py
+++ b/custom_components/localtuya/core/cloud_api.py
@@ -178,7 +178,11 @@ class TuyaCloudApi:
     async def async_get_devices_list(self, force_update=False) -> str | None:
         """Obtain the list of devices associated to a user. - force_update will ignore last update check."""
 
-        interval = DEVICES_UPDATE_INTERVAL if not force_update else DEVICES_UPDATE_INTERVAL_FORCED
+        interval = (
+            DEVICES_UPDATE_INTERVAL
+            if not force_update
+            else DEVICES_UPDATE_INTERVAL_FORCED
+        )
         if int(time.time()) - (self._last_devices_update + interval) < 0:
             return _LOGGER.debug(f"Devices has been updated a minutes ago.")
 

--- a/custom_components/localtuya/core/cloud_api.py
+++ b/custom_components/localtuya/core/cloud_api.py
@@ -14,6 +14,7 @@ from requests.adapters import HTTPAdapter, Retry
 _LOGGER = logging.getLogger(__name__)
 
 DEVICES_UPDATE_INTERVAL = 300
+DEVICES_UPDATE_INTERVAL_FORCED = 10
 
 TUYA_ENDPOINTS = {
     # Regions code
@@ -177,7 +178,8 @@ class TuyaCloudApi:
     async def async_get_devices_list(self, force_update=False) -> str | None:
         """Obtain the list of devices associated to a user. - force_update will ignore last update check."""
 
-        if not force_update and (int(time.time()) - self._last_devices_update) < 0:
+        interval = DEVICES_UPDATE_INTERVAL if not force_update else DEVICES_UPDATE_INTERVAL_FORCED
+        if int(time.time()) - (self._last_devices_update + interval) < 0:
             return _LOGGER.debug(f"Devices has been updated a minutes ago.")
 
         resp = await self.async_make_request(
@@ -206,7 +208,7 @@ class TuyaCloudApi:
         ]
         # await asyncio.run(*get_functions)
 
-        self._last_devices_update = int(time.time()) + DEVICES_UPDATE_INTERVAL
+        self._last_devices_update = int(time.time())
         return "ok"
 
     async def async_get_device_specifications(self, device_id) -> dict[str, dict]:

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -742,7 +742,7 @@ class TuyaListener(ABC):
         """Device disconnected."""
 
     @abstractmethod
-    def subdevice_state(self, state):
+    def subdevice_state(self, state: SubdeviceState):
         """Device is offline or online."""
 
 
@@ -755,7 +755,7 @@ class EmptyListener(TuyaListener):
     def disconnected(self, exc=""):
         """Device disconnected."""
 
-    def subdevice_state(self, state):
+    def subdevice_state(self, state: SubdeviceState):
         """Device is offline or online."""
 
 

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -1019,6 +1019,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         if self.heartbeater:
             self.heartbeater.cancel()
 
+        if self._sub_devs_query_task:
+            self._sub_devs_query_task.cancel()
+
         if self.dispatcher:
             self.dispatcher.abort()
 

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -46,6 +46,7 @@ import logging
 import struct
 import time
 import weakref
+from enum import Enum
 from abc import ABC, abstractmethod
 from typing import Self
 from collections import namedtuple
@@ -734,8 +735,13 @@ class TuyaListener(ABC):
     def disconnected(self, exc=""):
         """Device disconnected."""
 
+    class SubdeviceState(Enum):
+        ONLINE = 1
+        OFFLINE = 2
+        ABSENT = 3
+
     @abstractmethod
-    def subdevice_state(self, is_online):
+    def subdevice_state(self, state):
         """Device is offline or online."""
 
 
@@ -748,7 +754,7 @@ class EmptyListener(TuyaListener):
     def disconnected(self, exc=""):
         """Device disconnected."""
 
-    def subdevice_state(self, is_online):
+    def subdevice_state(self, state):
         """Device is offline or online."""
 
 
@@ -845,11 +851,21 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
                 self.debug(f"Sub-Devices States Update: {self.sub_devices_states}")
                 on_devs = self.sub_devices_states.get("online")
+                off_devs = self.sub_devices_states.get("offline")
                 listener = self.listener and self.listener()
-                if listener is None or on_devs is None:
+                if listener is None or (on_devs is None and off_devs is None):
                     return
-                for cid, device in listener.sub_devices.items():
-                    device.subdevice_state(cid in on_devs)
+                # listener.sub_devices can be changed when an absent sub-device is removed from,
+                # or re-connected sub-deviceis added to it. Such an event causes
+                #     RuntimeError: dictionary changed size during iteration
+                subdevices = dict(listener.sub_devices)
+                for cid, device in subdevices.items():
+                    if cid in on_devs:
+                        device.subdevice_state(TuyaListener.SubdeviceState.ONLINE)
+                    elif cid in off_devs:
+                        device.subdevice_state(TuyaListener.SubdeviceState.OFFLINE)
+                    else:
+                        device.subdevice_state(TuyaListener.SubdeviceState.ABSENT)
             except asyncio.CancelledError:
                 pass
 


### PR DESCRIPTION
Here it is. Now sub-devices offline, online and absent events are handled separately. In my tests I found out that if I remove a Zigbee subdevice without deleting its information, it keeps its cid even after connecting to another gateway. So, the proposed changes work and were tested for both BLE and Zigbee subdevices.

In my tests, I faced a weird behavior of my both BLE-capable gateways. If I detach a sub-device from it and then attach back, _sometimes_ they start reporting as online (as the reply for  `_sub_devs_query_task`) two different lists for odd and even requests: either with this detached/attached subdivce, or with the rest of subdevices. The gateways answer such a way until disconnect and reconnect. In logs, messages "Sub-device is absent" and "Sub-device is back" are shown, but, due, to the logic, nothing more happens. This is one of the reasons I decided not to call `disconnect` on the first `SubdeviceState.ABSENT` event.

I've added 10 seconds delay between forced `async_get_devices_list` for the case when there are 2 or more sub-devices need local key or gateway updates. 300 seconds default delay is too much for this action. I didn't find other `async_get_devices_list` calls apart from at the start and in `update_local_key`, but decided to keep the original 300 seconds delay.

Actually, there are not much changes in `update_local_key`, if you turn off comparing white spaces.

Note, that I added explicit cancel of `_sub_devs_query_task` after I saw it running when connection was already closed.

I used `Enum` instead of usual plain numbers, because I think it is a better style 😄  But I had to import `TuyaListener` for this purpose, and added `ContextualLogger` to the import just in case.

I think I explained all possibly questionable changes.