### PR TITLE
Call disconnect() only once for offlined sub-device

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -452,7 +452,7 @@ async def async_remove_orphan_entities(hass, entry):
 
 @callback
 def check_if_device_disabled(hass: HomeAssistant, entry: ConfigEntry, dev_id):
-    """Return whether if the device disbaled or not."""
+    """Return whether if the device disabled or not."""
     ent_reg = er.async_get(hass)
     entries = er.async_entries_for_config_entry(ent_reg, entry.entry_id)
     ha_device_id: str = None

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -593,7 +593,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             off_count += 1
             if off_count == 1:
                 self.warning(f"Sub-device is offline {node_id}")
-            elif off_count >= MIN_OFFLINE_EVENTS:
+            elif off_count == MIN_OFFLINE_EVENTS:
                 self.disconnected("Device is offline")
 
     def _remove_from_gateway(self):


### PR DESCRIPTION
This is the only, rather cosmetic, problem faced during the whole August non-stop running.

Also found old typo error quickly reading your recent changes, yet to fully review them before applying the update to my current version.