### PR TITLE
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'

### DIFF
--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -73,18 +73,11 @@ class LocalTuyaSwitch(LocalTuyaEntity, SwitchEntity):
         if self.has_config(CONF_CURRENT):
             attrs[ATTR_CURRENT] = self.dp_value(self._config[CONF_CURRENT])
         if self.has_config(CONF_CURRENT_CONSUMPTION):
-            value_cc = self.dp_value(self._config[CONF_CURRENT_CONSUMPTION])
-            if value_cc is not None:
-                attrs[ATTR_CURRENT_CONSUMPTION] = value_cc / 10
-            else:
-                attrs[ATTR_CURRENT_CONSUMPTION] = None
-
+            val_cc = self.dp_value(self._config[CONF_CURRENT_CONSUMPTION])
+            attrs[ATTR_CURRENT_CONSUMPTION] = None if val_cc is None else val_cc / 10
         if self.has_config(CONF_VOLTAGE):
-            value_v = attrs[ATTR_VOLTAGE] = self.dp_value(self._config[CONF_VOLTAGE])
-            if value_v is not None:
-                attrs[ATTR_VOLTAGE] = value_v / 10
-            else:
-                attrs[ATTR_VOLTAGE] = None
+            val_vol = self.dp_value(self._config[CONF_VOLTAGE])
+            attrs[ATTR_VOLTAGE] = None if val_vol is None else val_vol / 10
 
         # Store the state
         if self._state is not None:

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -73,11 +73,18 @@ class LocalTuyaSwitch(LocalTuyaEntity, SwitchEntity):
         if self.has_config(CONF_CURRENT):
             attrs[ATTR_CURRENT] = self.dp_value(self._config[CONF_CURRENT])
         if self.has_config(CONF_CURRENT_CONSUMPTION):
-            attrs[ATTR_CURRENT_CONSUMPTION] = (
-                self.dp_value(self._config[CONF_CURRENT_CONSUMPTION]) / 10
-            )
+            value_cc = self.dp_value(self._config[CONF_CURRENT_CONSUMPTION])
+            if value_cc is not None:
+                attrs[ATTR_CURRENT_CONSUMPTION] = value_cc / 10
+            else:
+                attrs[ATTR_CURRENT_CONSUMPTION] = None
+
         if self.has_config(CONF_VOLTAGE):
-            attrs[ATTR_VOLTAGE] = self.dp_value(self._config[CONF_VOLTAGE]) / 10
+            value_v = attrs[ATTR_VOLTAGE] = self.dp_value(self._config[CONF_VOLTAGE])
+            if value_v is not None:
+                attrs[ATTR_VOLTAGE] = value_v / 10
+            else:
+                attrs[ATTR_VOLTAGE] = None
 
         # Store the state
         if self._state is not None:


### PR DESCRIPTION
This is to fix "TypeError" durin HA startup.
```
  File "/config/custom_components/localtuya/switch.py", line 82, in extra_state_attributes
    attrs[ATTR_VOLTAGE] = self.dp_value(self._config[CONF_VOLTAGE]) / 10
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```