### PR TITLE
Fix cover async_stop_after_timeout dead task

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -104,6 +104,7 @@ class LocalTuyaCover(LocalTuyaEntity, CoverEntity):
         self._set_new_position = int | None
         self._stop_switch = self._config.get(CONF_STOP_SWITCH_DP, None)
         self._position_inverted = self._config.get(CONF_POSITION_INVERTED)
+        self._current_task = None
 
     @property
     def supported_features(self):
@@ -177,13 +178,12 @@ class LocalTuyaCover(LocalTuyaEntity, CoverEntity):
             mydelay = posdiff / 100.0 * self._config[CONF_SPAN_TIME]
             if newpos > currpos:
                 self.debug("Opening to %f: delay %f", newpos, mydelay)
-                await self.async_open_cover()
+                await self.async_open_cover(delay=mydelay)
                 self.update_state(STATE_OPENING)
             else:
                 self.debug("Closing to %f: delay %f", newpos, mydelay)
-                await self.async_close_cover()
+                await self.async_close_cover(delay=mydelay)
                 self.update_state(STATE_CLOSING)
-            self.hass.async_create_task(self.async_stop_after_timeout(mydelay))
             self.debug("Done")
 
         elif self._config[CONF_POSITIONING_MODE] == MODE_SET_POSITION:
@@ -200,19 +200,25 @@ class LocalTuyaCover(LocalTuyaEntity, CoverEntity):
 
     async def async_stop_after_timeout(self, delay_sec):
         """Stop the cover if timeout (max movement span) occurred."""
-        await asyncio.sleep(delay_sec)
-        await self.async_stop_cover()
+        try:
+            await asyncio.sleep(delay_sec)
+            self._current_task = None
+            await self.async_stop_cover()
+        except asyncio.CancelledError:
+            self._current_task = None
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
         self.debug("Launching command %s to cover ", self._open_cmd)
         await self._device.set_dp(self._open_cmd, self._dp_id)
         if self._config[CONF_POSITIONING_MODE] == MODE_TIME_BASED:
+            if self._current_task is not None:
+                self._current_task.cancel()
             # for timed positioning, stop the cover after a full opening timespan
             # instead of waiting the internal timeout
-            self.hass.async_create_task(
+            self._current_task = self.hass.async_create_task(
                 self.async_stop_after_timeout(
-                    self._config[CONF_SPAN_TIME] + COVER_TIMEOUT_TOLERANCE
+                    kwargs.get("delay", self._config[CONF_SPAN_TIME] + COVER_TIMEOUT_TOLERANCE)
                 )
             )
         self.update_state(STATE_OPENING)
@@ -222,17 +228,21 @@ class LocalTuyaCover(LocalTuyaEntity, CoverEntity):
         self.debug("Launching command %s to cover ", self._close_cmd)
         await self._device.set_dp(self._close_cmd, self._dp_id)
         if self._config[CONF_POSITIONING_MODE] == MODE_TIME_BASED:
+            if self._current_task is not None:
+                self._current_task.cancel()
             # for timed positioning, stop the cover after a full opening timespan
             # instead of waiting the internal timeout
-            self.hass.async_create_task(
+            self._current_task = self.hass.async_create_task(
                 self.async_stop_after_timeout(
-                    self._config[CONF_SPAN_TIME] + COVER_TIMEOUT_TOLERANCE
+                    kwargs.get("delay", self._config[CONF_SPAN_TIME] + COVER_TIMEOUT_TOLERANCE)
                 )
             )
         self.update_state(STATE_CLOSING)
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
+        if self._current_task is not None:
+            self._current_task.cancel()
         self.debug("Launching command %s to cover ", self._stop_cmd)
         command = {self._dp_id: self._stop_cmd}
         if self._stop_switch is not None:


### PR DESCRIPTION
Hi xZetsubou!

I had a problem with my shutter in timed mode, when I opened it then paused it, then reopened it, the previous task async_stop_after_timeout paused the shutter again, because the previous task was never canceled when I paused the 1st time.

It's now fix !