### PR TITLE
Avoid multithreading and other fixes

### DIFF
--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -507,7 +507,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
 
     def _shutdown_entities(self, exc=""):
         """Shutdown device entities"""
-        if self.is_sleep or self.connected:
+        if not self._is_closing and (self.is_sleep or self.connected):
             return
 
         signal = f"localtuya_{self._device_config.id}"

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -505,7 +505,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                     data = {"dp": dpid_trigger, "value": dpid_value}
                     fire_event(event, data)
 
-    def _shutdown_entities(self, now=None, exc=""):
+    def _shutdown_entities(self, exc=""):
         """Shutdown device entities"""
         if self.is_sleep or self.connected:
             return

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -462,7 +462,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                 break
 
             attempts += 1
-            scale = 1 if not self._subdevice_absent else 2
+            scale = 1 if not (self._subdevice_absent or attempts > MIN_OFFLINE_EVENTS) else 2
             await asyncio.sleep(scale * RECONNECT_INTERVAL.total_seconds())
 
         self._reconnect_task = False

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -560,8 +560,10 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             return
 
         self._call_on_close.append(asyncio.create_task(self._async_reconnect()).cancel)
-        fun = partial(self._shutdown_entities, exc=exc)
-        self._call_on_close.append(async_call_later(self._hass, 3 + sleep_time, fun))
+        func = partial(self._shutdown_entities, exc=exc)
+        self._call_on_close.append(
+            asyncio.get_event_loop().call_later(3 + sleep_time, func).cancel
+        )
 
     @callback
     def subdevice_state(self, state: SubdeviceState):


### PR DESCRIPTION
8304b61368a6528d9f6cd386915c3a8f2e3814f2:
`_shutdown_entities` checks several properties and members that could be changed during connection process. So, to avoid possible race conditions, it is better to call it from the main thread loop of LocalTuya, rather than from HASS thread loop. Instead, a device's entities could be disabled right after successful re-connect. Frankly, I never experienced such a misbehavior.

70970c9b4308154672488bbfb3ac5a8d28f37559:
After several unsuccessful re-connect attempts, it is good to decide that the device is offline and increase delay between further attempts. Just like for sub-devices that were reported as offline by their gateways.

d0a95392f364fd6953c2a15b7e136f2d9c1207f5:
On close event, `_shutdown_entities`, actually, did nothing for low power and currently connected devices. Actually, this call has rather cosmetic effect, because the entities are removed from HASS in a moment. But, while it is there, better to make it right way.