### PR TITLE
Unload and shutdown refactor

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -368,6 +368,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
+    async def _shutdown(event):
+        """Clean up resources when shutting down."""
+        for dev in connect_to_devices:
+            await dev.close()
+        _LOGGER.info("Shutdown completed")
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown)
+    )
+
     _LOGGER.info("Setup completed")
     return True
 

--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -47,8 +47,6 @@ from .discovery import TuyaDiscovery
 
 _LOGGER = logging.getLogger(__name__)
 
-UNSUB_LISTENER = "unsub_listener"
-
 CONF_DP = "dp"
 CONF_VALUE = "value"
 
@@ -318,7 +316,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass, tuya_api.async_connect(), "localtuya-cloudAPI"
         )
 
-    hass_localtuya = HassLocalTuyaData(tuya_api, {}, [])
+    hass_localtuya = HassLocalTuyaData(tuya_api, {})
     hass.data[DOMAIN][entry.entry_id] = hass_localtuya
 
     def _setup_devices(entry_devices: dict):
@@ -362,29 +360,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await async_remove_orphan_entities(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS.values())
 
-    hass_localtuya.unsub_listeners.append(entry.add_update_listener(update_listener))
+    # Note: entry.async_on_unload items are called in LIFO order!
 
     for dev in connect_to_devices:
         asyncio.create_task(dev.async_connect())
+        entry.async_on_unload(dev.close)
 
+    entry.async_on_unload(entry.add_update_listener(update_listener))
+
+    _LOGGER.info("Setup completed")
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unloading the Tuya platforms."""
-    hass_data: HassLocalTuyaData = hass.data[DOMAIN][entry.entry_id]
-
-    # Unsub listeners.
-    [unsub() for unsub in hass_data.unsub_listeners]
-
-    for dev in hass_data.devices.values():
-        asyncio.create_task(dev.close())
-
     # Unload the platforms.
     await hass.config_entries.async_unload_platforms(entry, PLATFORMS.values())
-
     hass.data[DOMAIN].pop(entry.entry_id)
 
+    _LOGGER.info("Unload completed")
     return True
 
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -51,7 +51,6 @@ class HassLocalTuyaData(NamedTuple):
 
     cloud_data: TuyaCloudApi
     devices: dict[str, TuyaDevice]
-    unsub_listeners: list[CALLBACK_TYPE,]
 
 
 class TuyaDevice(TuyaListener, ContextualLogger):

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -1599,7 +1599,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
     @property
     def is_connected(self):
-        return not self.transport or not self.transport.is_closing()
+        return self.transport is not None and not self.transport.is_closing()
 
     @property
     def last_command_sent(self):

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -962,6 +962,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                     self.exception("Heartbeat failed (%s), disconnecting", ex)
                     break
 
+            self.heartbeater = None
             if self.transport is not None:
                 self.clean_up_session()
 
@@ -1013,6 +1014,12 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         self.debug("Closing connection")
         self.clean_up_session()
 
+        if self.heartbeater:
+            await self.heartbeater
+
+        if self._sub_devs_query_task:
+            await self._sub_devs_query_task
+
     def clean_up_session(self):
         """Clean up session."""
         self.debug(f"Cleaning up session.")
@@ -1024,11 +1031,11 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         if self._sub_devs_query_task:
             self._sub_devs_query_task.cancel()
 
-        if self.dispatcher:
-            self.dispatcher.abort()
-
         if self.is_connected:
             self.transport.close()
+
+        if self.dispatcher:
+            self.dispatcher.abort()
 
     async def exchange_quick(self, payload, recv_retries):
         """Similar to exchange() but never retries sending and does not decode the response."""
@@ -1045,8 +1052,8 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         try:
             await self.transport_write(enc_payload)
         except Exception:  # pylint: disable=broad-except
-            await self.close()
-            return None
+            return self.clean_up_session()
+
         while recv_retries:
             try:
                 seqno = MessageDispatcher.SESS_KEY_SEQNO


### PR DESCRIPTION
**The general problems:**
- On LocalTuya unload (when disabled or restarted), `TuyaDevice.close()` calls were only put into async tasks queue, to run later. On restart, the queue is processed only after the call to `async_setup_entry()`, i.e. along with already created `async_connect()` tasks. Both `close()` and `async_connect()` have several `await` calls, meaning, the processes of closing old and creating new connections were overlapped.
- LocalTuya never closed the devices (and connections!) by itself. On HA shutdown, disconnects happened while the system was closing sockets, but LocalTuya devices immediatelly reconnected, and the restarr logs were full of complains like this:
```
2024-10-05 10:23:14.961 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback async_dispatcher_send_internal(<HomeAssistant STOPPED>, 'localtuya_bf...e5245a5cafhco', None) at /usr/src/homeassistant/homeassistant/helpers/dispatcher.py:218 (None)
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/helpers/dispatcher.py", line 251, in async_dispatcher_send_internal
    hass.async_run_hass_job(job, *args)
  File "/usr/src/homeassistant/homeassistant/core.py", line 940, in async_run_hass_job
    return self._async_add_hass_job(hassjob, *args, background=background)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 768, in _async_add_hass_job
    task = self.loop.run_in_executor(None, hassjob.target, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 856, in run_in_executor
    self._check_default_executor()
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 545, in _check_default_executor
    raise RuntimeError('Executor shutdown has been called')
RuntimeError: Executor shutdown has been called
```
or
```
2024-10-05 10:23:23.021 WARNING (MainThread) [homeassistant.util.executor] Thread[SyncWorker_20] is still running at shutdown: File "/usr/local/lib/python3.12/threading.py", line 1030, in _bootstrap
    self._bootstrap_inner()
  File "/usr/local/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 89, in _worker
    work_item = work_queue.get(block=True)
```
**The solutions:**
1. Call `TuyaDevice.close()` syncronously (with `await`), also trying to finalize all the subsequent asynchonous tasks.
2. Call `TuyaDevice.close()` on shutdown event.

It is better to use HA tools intended for these purposes: `entry.async_on_unload` for tasks to run at `async_unload_entry()` time, to both close devices and unsubscribe from events.

To minimize the number of tasks, and to prevent reconnects during unload or shutdown, I've made (fake) gateways to close its sub-devices.

The commit f36edb04175aafffeb4f6207cb206988dab97794 fixes a bug that never showed up in real life. But note these lines:
https://github.com/xZetsubou/hass-localtuya/blob/2ed259f345fc9b5811aca048580e84d5d539e099/custom_components/localtuya/core/pytuya/__init__.py#L1030-L1031
which presume that `self.is_connected` means `self.transport` is not `None`.
