### PR TITLE
Don't update seqno from a delayed reply

### DIFF
--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -894,7 +894,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 if msg.seqno >= self.seqno:
                     self.seqno = msg.seqno + 1
                 if ack:
-                    self.debug(f"Got update ack message update seqno only. msg.seqno={msg.seqno} self.seqno={self.seqno}")
+                    self.debug(
+                        f"Got update ack message update seqno only. msg.seqno={msg.seqno} self.seqno={self.seqno}"
+                    )
                     return
 
             decoded_message: dict = self._decode_payload(msg.payload)

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -891,9 +891,10 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
     def _setup_dispatcher(self) -> MessageDispatcher:
         def _status_update(msg, ack=False):
             if msg.seqno > 0:
-                self.seqno = msg.seqno + 1
+                if msg.seqno >= self.seqno:
+                    self.seqno = msg.seqno + 1
                 if ack:
-                    self.debug(f"Got update ack message update seqno only. {msg.seqno}")
+                    self.debug(f"Got update ack message update seqno only. msg.seqno={msg.seqno} self.seqno={self.seqno}")
                     return
 
             decoded_message: dict = self._decode_payload(msg.payload)


### PR DESCRIPTION
Thinking about "listener exists for {seqno}" problem, I've put
```python
                if msg.seqno + 1 < self.seqno:
                    self.warning(f"msg.seqno {msg.seqno} vs self.seqno {self.seqno} ack={ack} msg.cmd={msg.cmd}")
```
right above
https://github.com/xZetsubou/hass-localtuya/blob/2ed259f345fc9b5811aca048580e84d5d539e099/custom_components/localtuya/core/pytuya/__init__.py#L894-L897
and today morning found in the logs (for WiFi bulb):
```
2024-10-08 07:14:44.490 WARNING (MainThread) [custom_components.localtuya.core.pytuya] [bf0...sti - ГЛ2: LED BULB W5K] msg.seqno 47263 vs self.seqno 47265 ack=False msg.cmd=8
```
It means, if more than one requests are processed in parallel (remember `await` switches between tasks!), it is possible that `self.seqno` is updated from a delayed reply, and then some value is used twice.

In this my particular situation, it didn't cause "listener exists for {seqno}" case. But, anyway, the fix is required.

It is worth to mention, that, at first, the condition was
```python
                if msg.seqno < self.seqno:
                    self.warning(f"msg.seqno {msg.seqno} vs self.seqno {self.seqno} ack={ack} msg.cmd={msg.cmd}")
```
i.e. even when updating `self.seqno` has no effect, but it is also "late reply" situation. This happens much more often, for instance, for a gateway:
```
2024-10-07 18:25:48.220 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6136 less than self.seqno 6137 ack=True msg.cmd=13
2024-10-07 18:30:22.378 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6185 less than self.seqno 6186 ack=True msg.cmd=13
2024-10-07 18:30:54.029 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6192 less than self.seqno 6193 ack=True msg.cmd=13
2024-10-07 18:31:25.262 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6200 less than self.seqno 6201 ack=True msg.cmd=13
2024-10-07 18:31:37.238 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6204 less than self.seqno 6205 ack=True msg.cmd=13
2024-10-07 18:32:34.461 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6216 less than self.seqno 6217 ack=True msg.cmd=13
2024-10-07 18:32:42.391 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6218 less than self.seqno 6219 ack=True msg.cmd=13
2024-10-07 18:33:28.047 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6229 less than self.seqno 6230 ack=True msg.cmd=13
2024-10-07 18:33:38.882 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6233 less than self.seqno 6234 ack=True msg.cmd=13
2024-10-07 18:51:02.241 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6408 less than self.seqno 6409 ack=True msg.cmd=13
2024-10-07 18:51:10.363 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6412 less than self.seqno 6413 ack=True msg.cmd=13
2024-10-07 18:59:11.463 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6496 less than self.seqno 6497 ack=True msg.cmd=13
2024-10-07 18:59:58.692 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6505 less than self.seqno 6506 ack=True msg.cmd=13
2024-10-07 19:00:32.013 INFO (MainThread) [custom_components.localtuya.core.pytuya] [bf5...wrf - ВС: Wired Zigbee gateway] msg.seqno 6515 less than self.seqno 6516 ack=True msg.cmd=13
```

This PR may (or may not) be a fix for #364.
