### PR TITLE
Explicit tasks cancel

### DIFF
--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -337,7 +337,6 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             return
 
         self._is_closing = True
-        await self._shutdown_entities()
 
         if self._task_connect is not None:
             self._task_connect.cancel()
@@ -549,11 +548,11 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                 self._task_shutdown_entities = None
                 return
 
-        signal = f"localtuya_{self._device_config.id}"
-        dispatcher_send(self._hass, signal, None)
-
         if self._is_closing:
             return
+
+        signal = f"localtuya_{self._device_config.id}"
+        dispatcher_send(self._hass, signal, None)
 
         if self.is_subdevice:
             self.info(f"Sub-device disconnected due to: {exc}")

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -88,7 +88,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
 
         self._task_connect: asyncio.Task | None = None
         self._task_reconnect: asyncio.Task | None = None
-        self._task_shutdown_entities: asyncio.Task | None = None
+        self._task__entities: asyncio.Task | None = None
         self._unsub_refresh: CALLBACK_TYPE | None = None
         self._unsub_new_entity: CALLBACK_TYPE | None = None
 
@@ -337,7 +337,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             return
 
         self._is_closing = True
-        await self._shutdown_entities()
+        await self.__entities()
 
         if self._task_connect is not None:
             self._task_connect.cancel()
@@ -355,8 +355,8 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             await self._task_reconnect
             self._task_reconnect = None
 
-        if self._task_shutdown_entities is not None:
-            self._task_shutdown_entities.cancel()
+        if self._task__entities is not None:
+            self._task__entities.cancel()
             await self._task_shutdown_entities
             self._task_shutdown_entities = None
 
@@ -448,7 +448,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                 pass
 
     async def _sleep(self, seconds) -> bool:
-        """Interruptable sleep"""
+        """Interruptable sleep. Returns True if cancelled."""
         try:
             await asyncio.sleep(seconds)
         except asyncio.CancelledError:

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -209,7 +209,8 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                 break  # Succeed break while loop
             except asyncio.CancelledError:
                 await self.abort_connect()
-                break
+                self._task_connect = None
+                return
             except OSError as e:
                 await self.abort_connect()
                 if e.errno == errno.EHOSTUNREACH and not self.is_sleep:
@@ -247,6 +248,10 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                 self.exception(f"Handshake with {host} failed: due to {type(e)}: {e}")
                 await self.abort_connect()
                 update_localkey = True
+            except asyncio.CancelledError:
+                await self.abort_connect()
+                self._task_connect = None
+                return
             except Exception as e:
                 if not (self._fake_gateway and "Not found" in str(e)):
                     e = "Sub device is not connected" if self.is_subdevice else e

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -579,7 +579,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                 sub_dev.disconnected("Gateway disconnected")
 
         if self._task_connect is not None:
-            self._task_connect.cancel("Device disconnected")
+            self._task_connect.cancel()
             self._task_connect = None
 
         # If it disconnects unexpectedly.

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -452,7 +452,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         try:
             await asyncio.sleep(seconds)
         except asyncio.CancelledError:
-            self.debug(f"Sleep({seconds}) interrupted")
+            self.debug(f"Sleep({seconds}) interrupted", force=True)
             return True
         return False
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -164,7 +164,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         # RuntimeError: dictionary changed size during iteration
         subdevices = list(self.sub_devices.values())
         for subdevice in subdevices:
-            if not self.connected:
+            if not self.connected or self._is_closing:
                 break
 
             await subdevice.async_connect()

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -350,15 +350,15 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         for subdevice in subdevices:
             await subdevice.close()
 
-        if self._task_shutdown_entities is not None:
-            self._task_shutdown_entities.cancel()
-            await self._task_shutdown_entities
-            self._task_shutdown_entities = None
-
         if self._task_reconnect is not None:
             self._task_reconnect.cancel()
             await self._task_reconnect
             self._task_reconnect = None
+
+        if self._task_shutdown_entities is not None:
+            self._task_shutdown_entities.cancel()
+            await self._task_shutdown_entities
+            self._task_shutdown_entities = None
 
         if self._unsub_new_entity is not None:
             self._unsub_new_entity()

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -533,6 +533,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             await asyncio.sleep(3 + self._device_config.sleep_time)
 
             if self.connected or self.is_sleep:
+                self._task_shutdown_entities = None
                 return
 
         signal = f"localtuya_{self._device_config.id}"

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -441,7 +441,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
     async def _async_refresh(self, _now):
         if self.connected:
             self.debug("Refreshing dps for device")
-            # This a workdaround for >= 3.4 devices, since there is an issue on waiting for the correct seqno
+            # This a workaround for >= 3.4 devices, since there is an issue on waiting for the correct seqno
             try:
                 await self._interface.update_dps(cid=self._node_id)
             except TimeoutError:

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -572,6 +572,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
 
         if self._unsub_refresh:
             self._unsub_refresh()
+            self._unsub_refresh = None
 
         if self.sub_devices:
             for sub_dev in self.sub_devices.values():

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -88,7 +88,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
 
         self._task_connect: asyncio.Task | None = None
         self._task_reconnect: asyncio.Task | None = None
-        self._task__entities: asyncio.Task | None = None
+        self._task_shutdown_entities: asyncio.Task | None = None
         self._unsub_refresh: CALLBACK_TYPE | None = None
         self._unsub_new_entity: CALLBACK_TYPE | None = None
 
@@ -337,7 +337,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             return
 
         self._is_closing = True
-        await self.__entities()
+        await self._shutdown_entities()
 
         if self._task_connect is not None:
             self._task_connect.cancel()
@@ -355,8 +355,8 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             await self._task_reconnect
             self._task_reconnect = None
 
-        if self._task__entities is not None:
-            self._task__entities.cancel()
+        if self._task_shutdown_entities is not None:
+            self._task_shutdown_entities.cancel()
             await self._task_shutdown_entities
             self._task_shutdown_entities = None
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -523,7 +523,11 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         """Shutdown device entities"""
         # Delay shutdown.
         if not self._is_closing:
-            await asyncio.sleep(3 + self._device_config.sleep_time)
+            try:
+                await asyncio.sleep(3 + self._device_config.sleep_time)
+            except asyncio.CancelledError as e:
+                self.debug(f"Shutdown entities task has been canceled: {e}", force=True)
+                return
 
             if self.connected or self.is_sleep:
                 self._task_shutdown_entities = None

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -601,8 +601,10 @@ class TuyaDevice(TuyaListener, ContextualLogger):
 
         if self._task_reconnect is None:
             self._task_reconnect = asyncio.create_task(self._async_reconnect())
-        if self._task_shutdown_entities is None:
-            self._task_shutdown_entities = asyncio.create_task(self._shutdown_entities(exc=exc))
+
+        if self._task_shutdown_entities is not None:
+            self._task_shutdown_entities.cancel()
+        self._task_shutdown_entities = asyncio.create_task(self._shutdown_entities(exc=exc))
 
     @callback
     def subdevice_state(self, state: SubdeviceState):

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -346,9 +346,13 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         for subdevice in self.sub_devices.values():
             await subdevice.close()
 
-        if self._unsub_new_entity is not None:
+        if self._unsub_new_entity:
             self._unsub_new_entity()
             self._unsub_new_entity = None
+
+        if self._unsub_refresh:
+            self._unsub_refresh()
+            self._unsub_refresh = None
 
         await self.abort_connect()
         self.debug("Closed connection", force=True)

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -602,6 +602,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             return self.disconnected("Device is absent")
         elif state == SubdeviceState.ABSENT:
             self.info(f"Sub-device is absent {node_id}")
+            return
         elif old_state == SubdeviceState.ABSENT:
             self.info(f"Sub-device is back {node_id}")
 

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -856,11 +856,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 listener = self.listener and self.listener()
                 if listener is None or (on_devs is None and off_devs is None):
                     return
-                # listener.sub_devices can be changed when an absent sub-device is removed from,
-                # or re-connected sub-deviceis added to it. Such an event causes
-                #     RuntimeError: dictionary changed size during iteration
-                subdevices = dict(listener.sub_devices)
-                for cid, device in subdevices.items():
+                for cid, device in listener.sub_devices.items():
                     if cid in on_devs:
                         device.subdevice_state(SubdeviceState.ONLINE)
                     elif cid in off_devs:

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -742,7 +742,7 @@ class TuyaListener(ABC):
         """Device disconnected."""
 
     @abstractmethod
-    def subdevice_state(self, state: SubdeviceState):
+    def subdevice_state_updated(self, state: SubdeviceState):
         """Device is offline or online."""
 
 
@@ -755,7 +755,7 @@ class EmptyListener(TuyaListener):
     def disconnected(self, exc=""):
         """Device disconnected."""
 
-    def subdevice_state(self, state: SubdeviceState):
+    def subdevice_state_updated(self, state: SubdeviceState):
         """Device is offline or online."""
 
 
@@ -1655,7 +1655,7 @@ async def connect(
             )
 
         raise ex
-    except Exception as ex:
+    except (Exception, asyncio.CancelledError) as ex:
         raise ex
     except:
         raise Exception(f"The host refused to connect")


### PR DESCRIPTION
I've started this set of changes when I realized that `TuyaDevice._call_on_close` permanently grows. Consider a WiFi battery powered T&H sensor that wakes up and sends measurements every 20 minutes, 3 times per hour. If it is configured with sleep time of 6 hours (21600 seconds), it generates 3 `_shutdown_entities` tasks per hour, 72 items in the `TuyaDevice._call_on_close` per day. Add here one `_new_entity_handler` per successful connect and `_async_reconnect` to re-connect, to have 3x72=216 items per day from one sensor alone, not counting other devices that may disconnect and re-connect. This is a memory leak.

Moreover, with this consideration, after 6 hours, 18 `_shutdown_entities` async tasks pilled up in the tasks queue, and then the queue always has at least 18 tasks to serve, from only one sensor. This is a waste of queue resources.

When I've implemented one `TuyaDevice` member per async task (`_task_reconnect`, `_task_shutdown_entities`, `_unsub_new_entity`) instead of `_call_on_close` to explicitly stop them in the `close()`, I've found out that `cancel()` does not actually stops a task which calls ` await asyncio.pause`! `asyncio.CancelledError` is raised for a task only if ` await asyncio.pause` is called in a `try` block, directly or indirectly. It means, for low power devices,  `_shutdown_entities` never stopped, and `_async_reconnect` stopped with a delay, during LocalTuya restart or shutdown. This could cause unexpected misbehavior. Probably, this was the reason why the original #363 code didn't work for you. So, `self._sleep()` was implemented and tested to confirm that now all the tasks stop instantly.

Please remember that all the async tasks are now running from the same loop, meaning, e.g. when `close()` is running, other tasks in the queue hang on `await` statements. But when `close()` itself executes `await`, any other task may continue running until either its end, or another `await`. That's why I've inserted several `and not self._is_closing` checks into `_make_connection()`, to avoid redundant work while waiting for the `_task_connect` to stop. Alternatively, `except asyncio.CancelledError/return` could be added to each and every `try` block, but it would make more lines of code.

I've renamed `_connect_task` -> `_task_connect` to have uniform names.

Frankly, I never saw `_new_entity_handler` being called, and I don't quite understand the conditions for it to be called. But I believe it's enough to set it only once, like other HASS callbacks.