### PR TITLE
Close order revert

### DIFF
--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -326,7 +326,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             self._task_connect = None
 
         if self._interface is not None:
-            await self._interface.)
+            await self._interface.close()
             self._interface = None
 
     async def check_connection(self):

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -326,7 +326,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             self._task_connect = None
 
         if self._interface is not None:
-            await self._interface.close()
+            await self._interface.)
             self._interface = None
 
     async def check_connection(self):
@@ -347,9 +347,11 @@ class TuyaDevice(TuyaListener, ContextualLogger):
 
         tasks = [self._task_shutdown_entities, self._task_reconnect, self._task_connect]
         pending_tasks = [task for task in tasks if task and task.cancel()]
-        pending_tasks += [self.abort_connect()]
+        pending_tasks += []
         await asyncio.gather(*pending_tasks, return_exceptions=True)
 
+        # Close subdevices first, to prevent them try to reconnect
+        # after gateway disconnected.
         for subdevice in self.sub_devices.values():
             await subdevice.close()
 
@@ -361,6 +363,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             self._unsub_refresh()
             self._unsub_refresh = None
 
+        await self.abort_connect()
         self.debug("Closed connection", force=True)
 
     async def update_local_key(self):

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -465,9 +465,6 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                     await asyncio.sleep(3)
                     continue
 
-                if self._is_closing:
-                    break
-
                 if not self._task_connect:
                     await self.async_connect()
                 if self._task_connect:
@@ -476,6 +473,9 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                 if self.connected:
                     if not self.is_sleep and attempts > 0:
                         self.info(f"Reconnect succeeded on attempt: {attempts}")
+                    break
+
+                if self._is_closing:
                     break
 
                 attempts += 1

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -347,7 +347,6 @@ class TuyaDevice(TuyaListener, ContextualLogger):
 
         tasks = [self._task_shutdown_entities, self._task_reconnect, self._task_connect]
         pending_tasks = [task for task in tasks if task and task.cancel()]
-        pending_tasks += []
         await asyncio.gather(*pending_tasks, return_exceptions=True)
 
         # Close subdevices first, to prevent them try to reconnect

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -858,11 +858,11 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                     return
                 for cid, device in listener.sub_devices.items():
                     if cid in on_devs:
-                        device.subdevice_state(SubdeviceState.ONLINE)
+                        device.subdevice_state_updated(SubdeviceState.ONLINE)
                     elif cid in off_devs:
-                        device.subdevice_state(SubdeviceState.OFFLINE)
+                        device.subdevice_state_updated(SubdeviceState.OFFLINE)
                     else:
-                        device.subdevice_state(SubdeviceState.ABSENT)
+                        device.subdevice_state_updated(SubdeviceState.ABSENT)
             except asyncio.CancelledError:
                 pass
 

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -1003,8 +1003,8 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             while self.last_command_sent < 0.050:
                 await asyncio.sleep(0.010)
 
-        self._last_command_sent = time.time()
-        self.transport.write(data)
+            self._last_command_sent = time.time()
+            self.transport.write(data)
 
     async def close(self):
         """Close connection and abort all outstanding listeners."""


### PR DESCRIPTION
It is essential first to close the sub-devices, to make their `_is_closing==True`, and only then disconnect the gateway. There was my comment that you've removed. Now I revert your change and put back the comment.