### PR TITLE
Fix fan.py

### DIFF
--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -70,8 +70,8 @@ class LocalTuyaFan(LocalTuyaEntity, FanEntity):
         self._direction = None
         self._percentage = None
         self._speed_range = (
-            int(self._config.get(CONF_FAN_SPEED_MIN)),
-            int(self._config.get(CONF_FAN_SPEED_MAX)),
+            int(self._config.get(CONF_FAN_SPEED_MIN, 1)),
+            int(self._config.get(CONF_FAN_SPEED_MAX, 9)),
         )
         self._ordered_list = self._config.get(CONF_FAN_ORDERED_LIST).split(",")
 

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -70,8 +70,8 @@ class LocalTuyaFan(LocalTuyaEntity, FanEntity):
         self._direction = None
         self._percentage = None
         self._speed_range = (
-            self._config.get(CONF_FAN_SPEED_MIN),
-            self._config.get(CONF_FAN_SPEED_MAX),
+            int(self._config.get(CONF_FAN_SPEED_MIN)),
+            int(self._config.get(CONF_FAN_SPEED_MAX)),
         )
         self._ordered_list = self._config.get(CONF_FAN_ORDERED_LIST).split(",")
 


### PR DESCRIPTION
int conversion of string speed ranges provided by fan that led to below exception at HA start and hence deactivation of fan entities.

Exception in _update_handler when dispatching 'localtuya_bf753e0f5ece46fcb58mv4': ({'20': True, '22': 900, '23': 0, '60': False, '62': 1, '63': 'reverse', '64': 0},) Traceback (most recent call last): File "/config/custom_components/localtuya/entity.py", line 177, in _update_handler self.status_updated() ~~~~~~~~~~~~~~~~~~~^^ File "/config/custom_components/localtuya/fan.py", line 240, in status_updated self._percentage = ranged_value_to_percentage( 
~~~~~~~~~~~~~~~~~~~~~~~~~~^ self._speed_range, int(current_speed) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ) ^ File "/usr/src/homeassistant/homeassistant/util/percentage.py", line 76, in ranged_value_to_percentage return scale_ranged_value_to_int_range(low_high_range, (1, 100), value) File "/usr/src/homeassistant/homeassistant/util/scaling.py", line 21, in scale_ranged_value_to_int_range source_offset = source_low_high_range[0] - 1 ~~~~~~~~~~~~~~~~~~~~~~~~~^~~ TypeError: unsupported operand type(s) for -: 'str' and 'int'