### PR TITLE
Handle power button

### DIFF
--- a/custom_components/localtuya/button.py
+++ b/custom_components/localtuya/button.py
@@ -5,6 +5,7 @@ from functools import partial
 
 import voluptuous as vol
 from homeassistant.components.button import DOMAIN, ButtonEntity
+from homeassistant.util import dt as dt_util
 
 from .entity import LocalTuyaEntity, async_setup_entry
 from .const import CONF_PASSIVE_ENTITY
@@ -37,5 +38,11 @@ class LocalTuyaButton(LocalTuyaEntity, ButtonEntity):
         """Press the button."""
         await self._device.set_dp(True, self._dp_id)
 
+    def status_updated(self):
+        """Device status was updated."""
+        super().status_updated()
+        state = str(self.dp_value(self._dp_id)).lower()
+        self._ButtonEntity__set_state(f"{state}_{dt_util.utcnow().isoformat()}")
+        self._status.pop(self._dp_id, None)
 
 async_setup_entry = partial(async_setup_entry, DOMAIN, LocalTuyaButton, flow_schema)


### PR DESCRIPTION
Hi,

I recently bought [this product](https://pl.aliexpress.com/item/1005006877383125.html?), but unfortunately, it doesn't work out of the box with local-tuya.

The issue is that the status is not updated if there’s no change in state. The button only reports a state change to ha when it sends alternating states (e.g., single_click followed by double_click), but it fails when only single_click is sent.

I view this pull request as more of a hack than a proper solution, but it works for me. As far as I can tell, buttons from ha core use a timestamp as a state. Since this button has three different signals (single_click, double_click, long_press), I added a value to handle it in automation. Alternatively, raw_state could be used in automation.

I’m aware this approach is more of a hack than a clean solution. I’m happy to explore better alternatives, but I’d like to ask a few questions before investing time into this:

* I considered adding the ability to override _update_handler and modify the status change check. However, this would involve copy-pasting most of the code with just one line changed, making it hard to maintain in the long run.
* Another idea is to extract the state change test into a single method that can be overridden. This seems cleaner to me.
Are there any other approaches you’d recommend?
* Regarding the state: I’m unsure if we should remove it, but it seems necessary here. In this PR, bypassing the state change test is a must. However, as far as I know, buttons don’t have a state (except timestamps).

Finally, I’m unsure how to handle the three different signals (single_click, double_click, long_press). Should they be part of a single entity, or would it be better to split them into three different entities? Splitting them might simplify automation implementation. However, based on my initial tests, the configuration code assumes that a single DP can only be handled by one entity.

Could you guide me on the best approach here?

Thanks!