### PR TITLE
perf(climate): Heuristic Action and fix heating

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -323,7 +323,6 @@ class LocalTuyaClimate(LocalTuyaEntity, ClimateEntity):
             if self._hvac_mode == HVACMode.FAN_ONLY:
                 self._hvac_action = HVACAction.FAN
 
-        # This exists from upstream, not sure the use case of this.
         if self._config.get(CONF_HEURISTIC_ACTION, False):
             if self._hvac_mode == HVACMode.HEAT:
                 if self._current_temperature < (

--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -115,6 +115,7 @@ SUPPORTED_TEMPERATURES = {
     f"Target Temperature: {UnitOfTemperature.CELSIUS} | Current Temperature {UnitOfTemperature.FAHRENHEIT}": SupportedTemps.C_F,
     f"Target Temperature: {UnitOfTemperature.FAHRENHEIT} | Current Temperature {UnitOfTemperature.CELSIUS}": SupportedTemps.F_C,
 }
+SUPPORTED_PRECISIONS = [0.01, PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]
 
 DEFAULT_TEMPERATURE_UNIT = SupportedTemps.C
 DEFAULT_PRECISION = PRECISION_TENTHS
@@ -136,11 +137,11 @@ def flow_schema(dps):
         vol.Optional(CONF_MIN_TEMP, default=DEFAULT_MIN_TEMP): vol.Coerce(float),
         vol.Optional(CONF_MAX_TEMP, default=DEFAULT_MAX_TEMP): vol.Coerce(float),
         vol.Optional(CONF_PRECISION, default=str(DEFAULT_PRECISION)): col_to_select(
-            [PRECISION_WHOLE, PRECISION_HALVES, PRECISION_TENTHS]
+            SUPPORTED_PRECISIONS
         ),
         vol.Optional(
             CONF_TARGET_PRECISION, default=str(DEFAULT_PRECISION)
-        ): col_to_select([PRECISION_WHOLE, PRECISION_HALVES, PRECISION_TENTHS]),
+        ): col_to_select(SUPPORTED_PRECISIONS),
         vol.Optional(CONF_HVAC_MODE_DP): col_to_select(dps, is_dps=True),
         vol.Optional(
             CONF_HVAC_MODE_SET, default=HVAC_MODE_SETS
@@ -322,8 +323,7 @@ class LocalTuyaClimate(LocalTuyaEntity, ClimateEntity):
             if self._hvac_mode == HVACMode.FAN_ONLY:
                 self._hvac_action = HVACAction.FAN
 
-        # This feature calculates HVAC Action (from HVACMode and target/current temperatures) if the device is unable to do it. 
-        # Useful when you operate real device, like air-vales, heater, cooler, etc.
+        # This exists from upstream, not sure the use case of this.
         if self._config.get(CONF_HEURISTIC_ACTION, False):
             if self._hvac_mode == HVACMode.HEAT:
                 if self._current_temperature < (


### PR DESCRIPTION
This feature calculates HVAC Action (from HVACMode and target/current temperatures) if the device is unable to do it. 
Useful when you operate real device, like air-vales, heater, cooler, etc.

The upstream code contained some unnecessary lines and worked only with heating mode (as anything other climate stuff). 

1. However the CURRENT_* constants were converted to HVACMode, instead of HVACAction, so this should be corrected.
2. The code is also updated to support Fan/Dry/HeatCool modes.
