### PR TITLE
Fix tox not checking anything on CI

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -28,4 +28,4 @@ jobs:
         python -m pip install --upgrade setuptools pip
         python -m pip install tox-gh-actions
     - name: Run tox
-      run: tox -q -p auto
+      run: tox

--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -1,11 +1,8 @@
 """The LocalTuya integration."""
 
 import asyncio
-from dataclasses import dataclass
 import logging
 import time
-from datetime import timedelta
-from typing import Any, NamedTuple
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
@@ -27,9 +24,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.event import async_track_time_interval
 
-from .coordinator import TuyaDevice, HassLocalTuyaData, TuyaCloudApi
 from .config_flow import ENTRIES_VERSION
 from .const import (
     ATTR_UPDATED_AT,
@@ -42,7 +37,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-
+from .coordinator import TuyaDevice, HassLocalTuyaData, TuyaCloudApi
 from .discovery import TuyaDiscovery
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -188,7 +188,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     new_version = ENTRIES_VERSION
     stored_entries = hass.config_entries.async_entries(DOMAIN)
     if config_entry.version == 1:
-        # This an old version of original integration no nned to put it here.
+        # This an old version of original integration no need to put it here.
         pass
     # Update to version 3
     if config_entry.version == 2:
@@ -530,9 +530,9 @@ def check_if_device_disabled(hass: HomeAssistant, entry: ConfigEntry, dev_id: st
     entries = er.async_entries_for_config_entry(ent_reg, entry.entry_id)
     ha_device_id: str = None
 
-    for entitiy in entries:
-        if dev_id in entitiy.unique_id:
-            ha_device_id = entitiy.device_id
+    for entity in entries:
+        if dev_id in entity.unique_id:
+            ha_device_id = entity.device_id
             break
 
     if ha_device_id and (device := dr.async_get(hass).async_get(ha_device_id)):

--- a/custom_components/localtuya/alarm_control_panel.py
+++ b/custom_components/localtuya/alarm_control_panel.py
@@ -1,12 +1,10 @@
 """Platform to present any Tuya DP as a Alarm."""
 
-from enum import StrEnum
 import logging
+from enum import StrEnum
 from functools import partial
-from .config_flow import col_to_select
 
 import voluptuous as vol
-from homeassistant.helpers import selector
 from homeassistant.components.alarm_control_panel import (
     DOMAIN,
     AlarmControlPanelEntity,
@@ -14,9 +12,10 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntityFeature,
     AlarmControlPanelState,
 )
+from homeassistant.helpers import selector
 
-from .entity import LocalTuyaEntity, async_setup_entry
 from .const import CONF_ALARM_SUPPORTED_STATES
+from .entity import LocalTuyaEntity, async_setup_entry
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/localtuya/button.py
+++ b/custom_components/localtuya/button.py
@@ -3,11 +3,9 @@
 import logging
 from functools import partial
 
-import voluptuous as vol
 from homeassistant.components.button import DOMAIN, ButtonEntity
 
 from .entity import LocalTuyaEntity, async_setup_entry
-from .const import CONF_PASSIVE_ENTITY
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -2,11 +2,8 @@
     # PRESETS and HVAC_MODE Needs to be handle in better way.
 """
 
-import asyncio
 import logging
 from functools import partial
-from .config_flow import col_to_select
-from homeassistant.helpers import selector
 
 import voluptuous as vol
 from homeassistant.components.climate import (
@@ -32,8 +29,9 @@ from homeassistant.const import (
     PRECISION_WHOLE,
     UnitOfTemperature,
 )
-from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
-from .entity import LocalTuyaEntity, async_setup_entry
+from homeassistant.helpers import selector
+
+from .config_flow import col_to_select
 from .const import (
     CONF_CURRENT_TEMPERATURE_DP,
     CONF_ECO_DP,
@@ -55,6 +53,7 @@ from .const import (
     CONF_FAN_SPEED_DP,
     CONF_FAN_SPEED_LIST,
 )
+from .entity import LocalTuyaEntity, async_setup_entry
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -161,7 +161,7 @@ def flow_schema(dps):
     }
 
 
-# Convertors
+# Converters
 def f_to_c(num):
     return (num - 32) * 5 / 9 if num else num
 
@@ -244,7 +244,7 @@ class LocalTuyaClimate(LocalTuyaEntity, ClimateEntity):
         self._min_temp = self._config.get(CONF_MIN_TEMP, DEFAULT_MIN_TEMP)
         self._max_temp = self._config.get(CONF_MAX_TEMP, DEFAULT_MAX_TEMP)
 
-        # Temperture unit
+        # Temperature unit
         self._temperature_unit = UnitOfTemperature.CELSIUS
 
     @property
@@ -396,7 +396,7 @@ class LocalTuyaClimate(LocalTuyaEntity, ClimateEntity):
             temperature = kwargs[ATTR_TEMPERATURE]
 
             if self._target_temp_forced_to_celsius:
-                # Revert temperture to Fahrenheit it was forced to celsius
+                # Revert temperature to Fahrenheit it was forced to celsius
                 temperature = round(c_to_f(temperature))
 
             temperature = round(temperature / self._precision_target)

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -4,23 +4,17 @@ import asyncio
 import errno
 import logging
 import time
-from importlib import import_module
-from functools import partial
 from collections.abc import Coroutine
-from typing import Any
 from copy import deepcopy
-
+from functools import partial
+from importlib import import_module
+from typing import Any
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.entity_registry as er
-from homeassistant.helpers.selector import (
-    SelectSelector,
-    SelectSelectorConfig,
-    SelectSelectorMode,
-    SelectOptionDict,
-)
 import voluptuous as vol
 from homeassistant import exceptions
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
@@ -40,12 +34,13 @@ from homeassistant.const import (
     EntityCategory,
 )
 from homeassistant.core import callback, HomeAssistant
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
-from markdown_it.common.entities import entities
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    SelectOptionDict,
+)
 
-from .coordinator import pytuya, TuyaCloudApi
-from .core.cloud_api import TUYA_ENDPOINTS
-from .core.helpers import templates, get_gateway_by_deviceid, gen_localtuya_entities
 from .const import (
     ATTR_UPDATED_AT,
     CONF_ADD_DEVICE,
@@ -76,6 +71,9 @@ from .const import (
     SUPPORTED_PROTOCOL_VERSIONS,
     CONF_DEVICE_SLEEP_TIME,
 )
+from .coordinator import pytuya, TuyaCloudApi
+from .core.cloud_api import TUYA_ENDPOINTS
+from .core.helpers import templates, get_gateway_by_deviceid, gen_localtuya_entities
 from .discovery import discover
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -41,6 +41,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback, HomeAssistant
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from markdown_it.common.entities import entities
 
 from .coordinator import pytuya, TuyaCloudApi
 from .core.cloud_api import TUYA_ENDPOINTS
@@ -337,7 +338,7 @@ class LocalTuyaOptionsFlowHandler(OptionsFlow):
                     for fail_dev in fails.values():
                         devices_fails += f"\n{fail_dev['name']}: {fail_dev['reason']}"
 
-                    msg = f"Sucessed devices: ``{len(devices)}``\n ```{devices_sucessed}\n```"
+                    msg = f"Succeeded devices: ``{len(devices)}``\n ```{devices_sucessed}\n```"
                     if fails:
                         msg += f" \n Failed devices: ``{len(fails)}``\n ```{devices_fails}\n```"
 
@@ -610,7 +611,7 @@ class LocalTuyaOptionsFlowHandler(OptionsFlow):
         errors = {}
         placeholders = {}
 
-        # Gather the informations
+        # Gather the information
         is_cloud = not self.config_entry.data.get(CONF_NO_CLOUD)
         dev_id = self.selected_device
         category = None
@@ -750,8 +751,8 @@ class LocalTuyaOptionsFlowHandler(OptionsFlow):
                     dev_id = self.device_data[CONF_DEVICE_ID]
                     new_data = self.config_entry.data.copy()
                     entry_id = self.config_entry.entry_id
-                    # Removing the unwanted entites.
-                    entitesNames = [
+                    # Removing the unwanted entities.
+                    entities_names = [
                         name.get(CONF_FRIENDLY_NAME)
                         for name in self.device_data[CONF_ENTITIES]
                     ]
@@ -760,7 +761,7 @@ class LocalTuyaOptionsFlowHandler(OptionsFlow):
                         ent.unique_id: ent.entity_id
                         for ent in er.async_entries_for_config_entry(ent_reg, entry_id)
                         if dev_id in ent.unique_id
-                        and ent.original_name not in entitesNames
+                        and ent.original_name not in entities_names
                     }
                     for entity_id in reg_entities.values():
                         ent_reg.async_remove(entity_id)
@@ -1315,7 +1316,7 @@ async def validate_input(hass: HomeAssistant, entry_id, data):
     # won't work in this case
     if not bypass_connection and error:
         raise error
-    # If bypass handshake. otherwise raise faild to make handshake with device.
+    # If bypass handshake. otherwise raise failed to make handshake with device.
     # --- Cloud: We will use the DPS found on cloud if exists.
     # --- No cloud: user will have to input the DPS manually.
     if not detected_dps_device and not (

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from typing import Any
+
 from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_ENTITIES,

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -1,33 +1,23 @@
 """Tuya Device API"""
 
 from __future__ import annotations
+
 import asyncio
 import errno
 import logging
 import time
 from datetime import timedelta
 from typing import Any, NamedTuple
-from functools import partial
 
-
-from homeassistant.core import HomeAssistant, CALLBACK_TYPE, callback, State
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID, CONF_DEVICES, CONF_HOST, CONF_DEVICE_ID
-from homeassistant.helpers.event import async_track_time_interval, async_call_later
+from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_DEVICE_ID
+from homeassistant.core import HomeAssistant, CALLBACK_TYPE, callback
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
-    async_dispatcher_send,
     dispatcher_send,
 )
+from homeassistant.helpers.event import async_track_time_interval
 
-from .core import pytuya
-from .core.cloud_api import TuyaCloudApi
-from .core.pytuya import (
-    HEARTBEAT_INTERVAL,
-    TuyaListener,
-    ContextualLogger,
-    SubdeviceState,
-)
 from .const import (
     ATTR_UPDATED_AT,
     CONF_GATEWAY_ID,
@@ -38,6 +28,14 @@ from .const import (
     DOMAIN,
     DeviceConfig,
     RESTORE_STATES,
+)
+from .core import pytuya
+from .core.cloud_api import TuyaCloudApi
+from .core.pytuya import (
+    HEARTBEAT_INTERVAL,
+    TuyaListener,
+    ContextualLogger,
+    SubdeviceState,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/localtuya/core/ha_entities/__init__.py
+++ b/custom_components/localtuya/core/ha_entities/__init__.py
@@ -164,7 +164,7 @@ def gen_localtuya_entities(localtuya_data: dict, tuya_category: str) -> list[dic
                     entities[entity.get(CONF_ID)] = entity
                     _LOGGER.debug(f"{device_name}: Entity configured: {entity}")
 
-    # sort entites by id
+    # sort entities by id
     sorted_ids = sorted(entities, key=int)
 
     # convert to list of configs

--- a/custom_components/localtuya/core/ha_entities/base.py
+++ b/custom_components/localtuya/core/ha_entities/base.py
@@ -1,5 +1,5 @@
-from enum import StrEnum
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any
 
 from homeassistant.const import (
@@ -7,10 +7,10 @@ from homeassistant.const import (
     CONF_ICON,
     CONF_ENTITY_CATEGORY,
     CONF_DEVICE_CLASS,
-    Platform,
     EntityCategory,
 )
-from ...const import CONF_CLEAN_AREA_DP, CONF_DPS_STRINGS, CONF_STATE_CLASS
+
+from ...const import CONF_STATE_CLASS
 
 
 # Obtain values from cloud data.

--- a/custom_components/localtuya/core/ha_entities/base.py
+++ b/custom_components/localtuya/core/ha_entities/base.py
@@ -23,7 +23,7 @@ class CLOUD_VALUE:
     `value_key(str)`: The "key" name of the targeted value.\n
     `prefer_type`: Convert values
             Integer: Type(value) ( int, float or str ).\n
-            Enums: convert the values to [dict or str splitted by comma, default is list].\n
+            Enums: convert the values to [dict or str split by comma, default is list].\n
     `remap_values(dict)`: Used to remap dict values, if prefer_type is dict.\n
     `reverse_dict(bool)`: Reverse dict keys, value, if prefer_type is dict.\n
     `scale(bool)`: For integers, scale final value.\n

--- a/custom_components/localtuya/core/ha_entities/binary_sensors.py
+++ b/custom_components/localtuya/core/ha_entities/binary_sensors.py
@@ -6,8 +6,9 @@
     Modified by: xZetsubou
 """
 
-from .base import DPCode, LocalTuyaEntity, CONF_DEVICE_CLASS, EntityCategory
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+from .base import DPCode, LocalTuyaEntity, EntityCategory
 
 CONF_STATE_ON = "state_on"
 

--- a/custom_components/localtuya/core/ha_entities/buttons.py
+++ b/custom_components/localtuya/core/ha_entities/buttons.py
@@ -5,7 +5,7 @@
     Modified by: xZetsubou
 """
 
-from .base import DPCode, LocalTuyaEntity, CONF_DEVICE_CLASS, EntityCategory
+from .base import DPCode, LocalTuyaEntity, EntityCategory
 
 BUTTONS: dict[str, tuple[LocalTuyaEntity, ...]] = {
     # Scene Switch

--- a/custom_components/localtuya/core/ha_entities/climates.py
+++ b/custom_components/localtuya/core/ha_entities/climates.py
@@ -9,10 +9,6 @@
 from homeassistant.components.climate import (
     HVACMode,
     HVACAction,
-    DEFAULT_MAX_TEMP,
-    DEFAULT_MIN_TEMP,
-    ATTR_MAX_TEMP,
-    ATTR_MIN_TEMP,
 )
 from homeassistant.const import CONF_TEMPERATURE_UNIT
 
@@ -35,7 +31,6 @@ from ...const import (
     CONF_TARGET_TEMPERATURE_DP,
     CONF_PRESET_DP,
 )
-
 
 UNIT_C = "celsius"
 UNIT_F = "fahrenheit"

--- a/custom_components/localtuya/core/ha_entities/covers.py
+++ b/custom_components/localtuya/core/ha_entities/covers.py
@@ -5,8 +5,9 @@
     Modified by: xZetsubou
 """
 
-from .base import DPCode, LocalTuyaEntity, CONF_DEVICE_CLASS, EntityCategory
 from homeassistant.components.cover import CoverDeviceClass
+
+from .base import DPCode, LocalTuyaEntity
 
 # from const.py this is temporarily.
 CONF_COMMANDS_SET = "commands_set"

--- a/custom_components/localtuya/core/ha_entities/fans.py
+++ b/custom_components/localtuya/core/ha_entities/fans.py
@@ -5,14 +5,13 @@
     Modified by: xZetsubou
 """
 
+from homeassistant.components.fan import DIRECTION_FORWARD, DIRECTION_REVERSE
+
 from .base import (
     DPCode,
     LocalTuyaEntity,
-    CONF_DEVICE_CLASS,
-    EntityCategory,
     CLOUD_VALUE,
 )
-from homeassistant.components.fan import DIRECTION_FORWARD, DIRECTION_REVERSE
 
 # from const.py this is temporarily
 CONF_FAN_SPEED_CONTROL = "fan_speed_control"

--- a/custom_components/localtuya/core/ha_entities/humidifiers.py
+++ b/custom_components/localtuya/core/ha_entities/humidifiers.py
@@ -6,19 +6,18 @@
     Modified by: xZetsubou
 """
 
-from .base import (
-    DPCode,
-    LocalTuyaEntity,
-    CONF_DEVICE_CLASS,
-    EntityCategory,
-    CLOUD_VALUE,
-)
 from homeassistant.components.humidifier import (
     HumidifierDeviceClass,
     ATTR_MAX_HUMIDITY,
     ATTR_MIN_HUMIDITY,
     DEFAULT_MAX_HUMIDITY,
     DEFAULT_MIN_HUMIDITY,
+)
+
+from .base import (
+    DPCode,
+    LocalTuyaEntity,
+    CLOUD_VALUE,
 )
 
 CONF_HUMIDIFIER_SET_HUMIDITY_DP = "humidifier_set_humidity_dp"

--- a/custom_components/localtuya/core/ha_entities/lights.py
+++ b/custom_components/localtuya/core/ha_entities/lights.py
@@ -7,9 +7,10 @@
 """
 
 from typing import Any
-from .base import DPCode, LocalTuyaEntity, EntityCategory, CLOUD_VALUE
-from homeassistant.const import CONF_BRIGHTNESS, CONF_COLOR_TEMP, CONF_SCENE
 
+from homeassistant.const import CONF_BRIGHTNESS
+
+from .base import DPCode, LocalTuyaEntity, EntityCategory, CLOUD_VALUE
 from ...const import (
     CONF_BRIGHTNESS_LOWER,
     CONF_BRIGHTNESS_UPPER,

--- a/custom_components/localtuya/core/ha_entities/selects.py
+++ b/custom_components/localtuya/core/ha_entities/selects.py
@@ -531,7 +531,7 @@ SELECTS: dict[str, tuple[LocalTuyaEntity, ...]] = {
             entity_category=EntityCategory.CONFIG,
             name="Record Mode",
             custom_configs=localtuya_selector(
-                {"1": "Record Events Only", "2": "Allways Record"}
+                {"1": "Record Events Only", "2": "Always Record"}
             ),
         ),
         LocalTuyaEntity(
@@ -710,7 +710,7 @@ SELECTS: dict[str, tuple[LocalTuyaEntity, ...]] = {
             name="Direction",
             custom_configs=localtuya_selector(
                 {
-                    "foward": "Forward",
+                    "forward": "Forward",
                     "backward": "Backward",
                     "turn_left": "Left",
                     "turn_right": "Right",
@@ -811,7 +811,7 @@ SELECTS: dict[str, tuple[LocalTuyaEntity, ...]] = {
             entity_category=EntityCategory.CONFIG,
             icon="mdi:cog-transfer",
             custom_configs=localtuya_selector(
-                {"contiuation": "Auto", "point": "Manual"}
+                {"continuation": "Auto", "point": "Manual"}
             ),
         ),
         LocalTuyaEntity(

--- a/custom_components/localtuya/core/ha_entities/selects.py
+++ b/custom_components/localtuya/core/ha_entities/selects.py
@@ -9,7 +9,6 @@
 from .base import (
     DPCode,
     LocalTuyaEntity,
-    CONF_DEVICE_CLASS,
     EntityCategory,
     CLOUD_VALUE,
 )

--- a/custom_components/localtuya/core/ha_entities/sensors.py
+++ b/custom_components/localtuya/core/ha_entities/sensors.py
@@ -8,12 +8,9 @@
 
 from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass
 from homeassistant.const import (
-    PERCENTAGE,
-    UnitOfTime,
     UnitOfPower,
     PERCENTAGE,
     UnitOfElectricCurrent,
-    UnitOfElectricPotential,
     UnitOfTime,
     CONF_UNIT_OF_MEASUREMENT,
     UnitOfTemperature,

--- a/custom_components/localtuya/core/ha_entities/sirens.py
+++ b/custom_components/localtuya/core/ha_entities/sirens.py
@@ -5,7 +5,7 @@
     Modified by: xZetsubou
 """
 
-from .base import DPCode, LocalTuyaEntity, CONF_DEVICE_CLASS, EntityCategory
+from .base import DPCode, LocalTuyaEntity
 
 # All descriptions can be found here:
 # https://developer.tuya.com/en/docs/iot/standarddescription?id=K9i5ql6waswzq

--- a/custom_components/localtuya/core/ha_entities/switches.py
+++ b/custom_components/localtuya/core/ha_entities/switches.py
@@ -6,8 +6,9 @@
     Modified by: xZetsubou
 """
 
-from .base import DPCode, LocalTuyaEntity, CONF_DEVICE_CLASS, EntityCategory
 from homeassistant.components.switch import SwitchDeviceClass
+
+from .base import DPCode, LocalTuyaEntity, EntityCategory
 
 CHILD_LOCK = (
     LocalTuyaEntity(

--- a/custom_components/localtuya/core/ha_entities/switches.py
+++ b/custom_components/localtuya/core/ha_entities/switches.py
@@ -790,7 +790,7 @@ SWITCHES: dict[str, tuple[LocalTuyaEntity, ...]] = {
     "fskg": (
         LocalTuyaEntity(
             id=DPCode.BACKLIGHT_SWITCH,
-            name="LED Siwtch",
+            name="LED Switch",
             icon="mdi:led-outline",
             entity_category=EntityCategory.CONFIG,
         ),

--- a/custom_components/localtuya/core/ha_entities/water_heaters.py
+++ b/custom_components/localtuya/core/ha_entities/water_heaters.py
@@ -14,8 +14,6 @@ from homeassistant.const import CONF_TEMPERATURE_UNIT
 
 from .base import DPCode, LocalTuyaEntity, CLOUD_VALUE
 from ...const import (
-    CONF_TARGET_TEMPERATURE_LOW_DP,
-    CONF_TARGET_TEMPERATURE_HIGH_DP,
     CONF_PRECISION,
     CONF_TARGET_PRECISION,
     CONF_CURRENT_TEMPERATURE_DP,
@@ -25,7 +23,6 @@ from ...const import (
     CONF_MODES,
     CONF_MODE_DP,
 )
-
 
 UNIT_C = "celsius"
 UNIT_F = "fahrenheit"

--- a/custom_components/localtuya/core/helpers.py
+++ b/custom_components/localtuya/core/helpers.py
@@ -2,16 +2,14 @@
 Helpers functions for HASS-LocalTuya.
 """
 
-import asyncio
 import logging
 import os.path
 from enum import Enum
 from fnmatch import fnmatch
 from typing import NamedTuple
 
-from homeassistant.util.yaml import load_yaml, dump
 from homeassistant.const import CONF_PLATFORM, CONF_ENTITIES
-
+from homeassistant.util.yaml import load_yaml, dump
 
 import custom_components.localtuya.templates as templates_dir
 
@@ -113,4 +111,3 @@ def get_gateway_by_deviceid(device_id: str, cloud_data: dict) -> GATEWAY:
 ###############################
 #    Auto configure device    #
 ###############################
-from .ha_entities import gen_localtuya_entities

--- a/custom_components/localtuya/entity.py
+++ b/custom_components/localtuya/entity.py
@@ -3,9 +3,7 @@
 import logging
 from typing import Any
 
-from homeassistant.core import HomeAssistant, State
 from homeassistant.config_entries import ConfigEntry
-
 from homeassistant.const import (
     CONF_DEVICES,
     CONF_DEVICE_CLASS,
@@ -14,24 +12,21 @@ from homeassistant.const import (
     CONF_FRIENDLY_NAME,
     CONF_HOST,
     CONF_ICON,
-    CONF_ID,
     CONF_PLATFORM,
     EntityCategory,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     ATTR_VIA_DEVICE,
 )
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
-
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
-from .core import pytuya
-from .coordinator import HassLocalTuyaData, TuyaDevice
 from .const import (
     ATTR_STATE,
     CONF_DEFAULT_VALUE,
@@ -44,6 +39,8 @@ from .const import (
     RESTORE_STATES,
     DeviceConfig,
 )
+from .coordinator import HassLocalTuyaData, TuyaDevice
+from .core import pytuya
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -3,7 +3,6 @@
 import logging
 import math
 from functools import partial
-from .config_flow import col_to_select
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -22,18 +21,18 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
-from .entity import LocalTuyaEntity, async_setup_entry
+from .config_flow import col_to_select
 from .const import (
     CONF_FAN_DIRECTION,
     CONF_FAN_DIRECTION_FWD,
     CONF_FAN_DIRECTION_REV,
-    CONF_FAN_DPS_TYPE,
     CONF_FAN_ORDERED_LIST,
     CONF_FAN_OSCILLATING_CONTROL,
     CONF_FAN_SPEED_CONTROL,
     CONF_FAN_SPEED_MAX,
     CONF_FAN_SPEED_MIN,
 )
+from .entity import LocalTuyaEntity, async_setup_entry
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/localtuya/humidifier.py
+++ b/custom_components/localtuya/humidifier.py
@@ -2,17 +2,12 @@
 
 import logging
 from functools import partial
-from .config_flow import col_to_select
-from homeassistant.helpers import selector
 
 import voluptuous as vol
-from homeassistant.const import CONF_DEVICE_CLASS
 from homeassistant.components.humidifier import (
     DOMAIN,
-    HumidifierDeviceClass,
     DEVICE_CLASSES_SCHEMA,
     HumidifierEntity,
-    HumidifierEntityDescription,
     HumidifierEntityFeature,
 )
 from homeassistant.components.humidifier.const import (
@@ -21,6 +16,10 @@ from homeassistant.components.humidifier.const import (
     DEFAULT_MAX_HUMIDITY,
     DEFAULT_MIN_HUMIDITY,
 )
+from homeassistant.const import CONF_DEVICE_CLASS
+from homeassistant.helpers import selector
+
+from .config_flow import col_to_select
 
 CONF_HUMIDIFIER_SET_HUMIDITY_DP = "humidifier_set_humidity_dp"
 CONF_HUMIDIFIER_CURRENT_HUMIDITY_DP = "humidifier_current_humidity_dp"

--- a/custom_components/localtuya/remote.py
+++ b/custom_components/localtuya/remote.py
@@ -2,19 +2,15 @@
 
 import asyncio
 import json
-import base64
 import logging
-from functools import partial
-import struct
 from enum import StrEnum
+from functools import partial
 from typing import Any, Iterable
-from .config_flow import col_to_select
 
 import voluptuous as vol
+from homeassistant.components import persistent_notification
 from homeassistant.components.remote import (
-    ATTR_ACTIVITY,
     ATTR_COMMAND,
-    ATTR_COMMAND_TYPE,
     ATTR_NUM_REPEATS,
     ATTR_DELAY_SECS,
     ATTR_DEVICE,
@@ -23,14 +19,14 @@ from homeassistant.components.remote import (
     RemoteEntity,
     RemoteEntityFeature,
 )
-from homeassistant.components import persistent_notification
-from homeassistant.const import CONF_DEVICE_ID, STATE_OFF
-from homeassistant.core import HomeAssistant, State
+from homeassistant.const import STATE_OFF
+from homeassistant.core import State
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.storage import Store
 
-from .entity import LocalTuyaEntity, async_setup_entry
+from .config_flow import col_to_select
 from .const import CONF_RECEIVE_DP, CONF_KEY_STUDY_DP
+from .entity import LocalTuyaEntity, async_setup_entry
 
 NSDP_CONTROL = "control"  # The control commands
 NSDP_TYPE = "type"  # The identifier of an IR library

--- a/custom_components/localtuya/remote.py
+++ b/custom_components/localtuya/remote.py
@@ -170,7 +170,7 @@ class LocalTuyaRemote(LocalTuyaEntity, RemoteEntity):
             raise ServiceValidationError(f"Remote {self.entity_id} is turned off")
 
         now, timeout = 0, kwargs.get(ATTR_TIMEOUT, 30)
-        sucess = False
+        success = False
 
         device = kwargs.get(ATTR_DEVICE)
         commands = kwargs.get(ATTR_COMMAND)
@@ -204,14 +204,14 @@ class LocalTuyaRemote(LocalTuyaEntity, RemoteEntity):
                             and dp_code is not None
                         ):
                             self._last_code = dp_code
-                            sucess = True
+                            success = True
                             await self.send_signal(ControlMode.STUDY_EXIT)
                             break
 
                         now += 1
                         await asyncio.sleep(1)
 
-                    if not sucess:
+                    if not success:
                         await self.send_signal(ControlMode.STUDY_EXIT)
                         raise ServiceValidationError(f"Failed to learn: {command}")
 
@@ -220,7 +220,7 @@ class LocalTuyaRemote(LocalTuyaEntity, RemoteEntity):
                         self.hass, notification_id="learn_command"
                     )
 
-                # code retrive sucess and it's sotred in self._last_code
+                # code retrieve success and it's sorted in self._last_code
                 # we will store the codes.
                 await self._save_new_command(device, command, self._last_code)
 

--- a/custom_components/localtuya/sensor.py
+++ b/custom_components/localtuya/sensor.py
@@ -2,24 +2,22 @@
 
 import logging
 from functools import partial
-from .config_flow import col_to_select
 
 import voluptuous as vol
 from homeassistant.components.sensor import (
     DEVICE_CLASSES_SCHEMA,
     DOMAIN,
-    STATE_CLASSES_SCHEMA,
     SensorStateClass,
     SensorEntity,
 )
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_UNIT_OF_MEASUREMENT,
-    STATE_UNKNOWN,
 )
 
-from .entity import LocalTuyaEntity, async_setup_entry
+from .config_flow import col_to_select
 from .const import CONF_SCALING, CONF_STATE_CLASS
+from .entity import LocalTuyaEntity, async_setup_entry
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -2,18 +2,16 @@
 
 import logging
 from functools import partial
-from .config_flow import col_to_select
 
 import voluptuous as vol
 from homeassistant.components.switch import (
     DOMAIN,
     SwitchEntity,
-    DEVICE_CLASSES_SCHEMA,
     SwitchDeviceClass,
 )
 from homeassistant.const import CONF_DEVICE_CLASS
 
-from .entity import LocalTuyaEntity, async_setup_entry
+from .config_flow import col_to_select
 from .const import (
     ATTR_CURRENT,
     ATTR_CURRENT_CONSUMPTION,
@@ -26,6 +24,7 @@ from .const import (
     CONF_RESTORE_ON_RECONNECT,
     CONF_VOLTAGE,
 )
+from .entity import LocalTuyaEntity, async_setup_entry
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/localtuya/templates/sample_2g_switch.yaml
+++ b/custom_components/localtuya/templates/sample_2g_switch.yaml
@@ -24,11 +24,11 @@
 
 # the configs depends on the platform and what input does platform support read bottom.
 
-# THERE Is 2 ways to make template:
-# - 1st is write the yaml ur self:
+# THERE are 2 ways to make template:
+# - 1st is to write the yaml yourself:
 # --[ Keep in mind there is no valid check atm ]
 
-# - 2st is to export ur device file from config flow. [ Recommended ]:
+# - 2nd is to export ur device file from config flow. [ Recommended ]:
 # -- in HA Dashboard go to [ Devices -> localtuya -> Configure -> Edit Device * choose the device u want to export
 # --- Export the device config then submit]
 
@@ -37,7 +37,7 @@
 
 # How to import:
 # -- When u add new device when the form [ Pick Entity type selection ]
-# --- Import template Form will show up showing avaliable templates in templates folder.
+# --- Import template Form will show up showing available templates in templates folder.
 
 # -- templates in [custom_components/localtuya/templates]
 # -- Templates files will load up with HA so adding files will require restarting HA to show up.

--- a/custom_components/localtuya/water_heater.py
+++ b/custom_components/localtuya/water_heater.py
@@ -2,8 +2,6 @@
 
 import logging
 from functools import partial
-from .config_flow import col_to_select
-from homeassistant.helpers import selector
 
 import voluptuous as vol
 from homeassistant.components.water_heater import (
@@ -13,14 +11,6 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
 )
-from homeassistant.components.water_heater.const import (
-    STATE_ECO,
-    STATE_ELECTRIC,
-    STATE_PERFORMANCE,
-    STATE_HIGH_DEMAND,
-    STATE_HEAT_PUMP,
-    STATE_GAS,
-)
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_TEMPERATURE_UNIT,
@@ -29,7 +19,9 @@ from homeassistant.const import (
     PRECISION_WHOLE,
     UnitOfTemperature,
 )
-from .entity import LocalTuyaEntity, async_setup_entry
+from homeassistant.helpers import selector
+
+from .config_flow import col_to_select
 from .const import (
     CONF_TARGET_TEMPERATURE_DP,
     CONF_CURRENT_TEMPERATURE_DP,
@@ -42,6 +34,7 @@ from .const import (
     CONF_TARGET_TEMPERATURE_LOW_DP,
     CONF_TARGET_TEMPERATURE_HIGH_DP,
 )
+from .entity import LocalTuyaEntity, async_setup_entry
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 skipsdist = true
-envlist =  py{38,39}, lint, typing
+envlist =  py{310}, lint, typing
 skip_missing_interpreters = True
 cs_exclude_words = hass,unvalid
 
 [gh-actions]
 python =
-  3.9: clean, py39, lint, typing
+  3.10: clean, py310, lint, typing
 
 [testenv]
 passenv = TOXENV,CI


### PR DESCRIPTION
Your repo has `tox` CI action. But it turns out, this action doesn't actually check anything. This PR fixes CI job, so it starts doing useful things. Unfortunately, it exposes lots of lint violations in your repo.

See [example CI run](https://github.com/slonopotamus/hass-localtuya/actions/runs/12704120893/job/35412984283) for the list of errors.

Just in case: I would prefer _not_ to fix all current violations in this PR because I am not very familiar with hass-localtuya codebase.