### PR TITLE
fix(climate): Preset mode always is null

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -357,7 +357,9 @@ class LocalTuyaClimate(LocalTuyaEntity, ClimateEntity):
     def preset_mode(self):
         """Return current preset."""
         mode = self.dp_value(CONF_HVAC_MODE_DP)
-        if mode in list(self._hvac_mode_set.values()):
+        if self._preset_dp == self._hvac_mode_dp and (
+            mode in list(self._hvac_mode_set.values())
+        ):
             return None
 
         return self._preset_mode


### PR DESCRIPTION
related: #486 

- Ensure the preset DP is the same HVAC mode DP before check.

- The condition would ensure that if preset and HVAC share same DP to not update preset mode if HVAC changed. this made because if preset contains more HVAC modes that aren't supported by HA would give user ability to change it otherwise state would be stuck to the latest one and would require to change it to another one then back.