### PR TITLE
Fix broken link

### DIFF
--- a/documentation/docs/usage/configure_add_device.md
+++ b/documentation/docs/usage/configure_add_device.md
@@ -140,7 +140,7 @@ Each platform has its unique configuration page with different sets of configura
 ##### Create templates
 There are two ways to create templates
 
-1. Export a configured device from the [Reconfigure existing device](/usage/configure_edit_device) step
+1. Export a configured device from the [Reconfigure existing device](../configure_edit_device) step
 2. Manually write the configuration __`YAML`__ file `Not Recommended`
 
 ??? example "`Cover` template example"

--- a/documentation/docs/usage/installation.md
+++ b/documentation/docs/usage/installation.md
@@ -28,5 +28,5 @@ If you haven't added the repository to `HACS`.
     a. If you prefer not to set up the cloud API, check `Disable Cloud API?`
 
     b. If you've set up a `cloud` account, you should have all the necessary information
-    <br> [Get authentication data](cloud_api.md/#get-authorization-data).
+    <br> [Get authentication data](../cloud_api.md/#get-authorization-data).
 


### PR DESCRIPTION
"Installation integration" has a "Get authorization data" which leads to 404 now, because target document placed in the parent directory.