### PR TITLE
fix(climate): add is_on property to support all on/off state types

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -1,6 +1,7 @@
 """Platform to locally control Tuya-based climate devices."""
 
 import asyncio
+from enum import StrEnum
 import logging
 from functools import partial
 from .config_flow import col_to_select
@@ -97,7 +98,6 @@ HVAC_ACTION_SETS = {
     HVACAction.HEATING: "opened",
     HVACAction.IDLE: "closed",
 }
-from enum import StrEnum
 
 
 class SupportedTemps(StrEnum):

--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -58,7 +58,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-HVAC_OFF = {HVACMode.OFF.value: "off"}
+HVAC_OFF = {HVACMode.OFF.value: "off"}  # Migrate to 3
 RENAME_HVAC_MODE_SETS = {  # Migrate to 3
     ("manual", "Manual", "hot", "m", "True"): HVACMode.HEAT.value,
     ("auto", "0", "p", "Program"): HVACMode.AUTO.value,
@@ -72,7 +72,7 @@ RENAME_ACTION_SETS = {  # Migrate to 3
     ("cooling"): HVACAction.COOLING.value,
     ("off"): HVACAction.OFF.value,
 }
-RENAME_PRESET_SETS = {
+RENAME_PRESET_SETS = {  # Migrate to 3
     "Holiday": (PRESET_AWAY),
     "Program": (PRESET_HOME),
     "Manual": (PRESET_NONE, "manual"),


### PR DESCRIPTION
Add is_on property to check the state of device.

- This is related to #496 where if the on/off are string and usef if not both will return true, implement is_on to handle these cases as well