### PR TITLE
fix(cloud_api): remove unnecessary calls

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -323,6 +323,7 @@ class LocalTuyaOptionsFlowHandler(OptionsFlow):
 
             if user_input.pop(CONF_MASS_CONFIGURE, False):
                 # Handle auto configure all recognized devices.
+                await self.cloud_data.async_get_devices_dps_query()
                 devices, fails = await setup_localtuya_devices(
                     self.hass,
                     self.config_entry.entry_id,
@@ -1308,8 +1309,8 @@ async def validate_input(hass: HomeAssistant, entry_id, data):
     # Get DP descriptions from the cloud, if the device is there.
     cloud_dp_codes = {}
     cloud_data: TuyaCloudApi = hass.data[DOMAIN][entry_id].cloud_data
-    if device_cloud_data := cloud_data.device_list.get(data[CONF_DEVICE_ID]):
-        cloud_dp_codes = device_cloud_data.get("dps_data", {})
+    if (dev_id := data.get(CONF_DEVICE_ID)) in cloud_data.device_list:
+        cloud_dp_codes = await cloud_data.async_get_device_functions(dev_id)
 
     # Indicate an error if no datapoints found as the rest of the flow
     # won't work in this case

--- a/custom_components/localtuya/core/cloud_api.py
+++ b/custom_components/localtuya/core/cloud_api.py
@@ -187,14 +187,18 @@ class TuyaCloudApi:
 
         self.device_list.update({dev["id"]: dev for dev in resp["result"]})
 
-        # Get Devices DPS Data.
-        await asyncio.wait(
-            asyncio.create_task(self.async_get_device_functions(devid))
-            for devid in self.device_list
-        )
-
         self._last_devices_update = int(time.time())
         return "ok"
+
+    async def async_get_devices_dps_query(self):
+        """Update All the devices dps_data."""
+        # Get Devices DPS Data.
+        async with aiohttp.ClientSession() as self._session:
+            await asyncio.wait(
+                asyncio.create_task(self.async_get_device_functions(devid))
+                for devid in self.device_list
+            )
+            return "ok"
 
     async def async_get_device_specifications(self, device_id) -> dict[str, dict]:
         """Obtain the DP ID mappings for a device."""


### PR DESCRIPTION
Explanation: Due to the fact that this fork contains more features, especially auto-configure entities, with the help of the Tuya API, we retrieve the devices’ DPS codes. Based on these codes, we use them to configure the entities.

Currently, each device makes “3” API calls to retrieve all the DPS codes, including the ones that are missing in the official HA Tuya integration. The main issue was that these calls would happen every time the integration loaded, which caused delays in device connection. Specifically, when the call happened in the middle of the connection process, it would slow down the connection more than it should have.

Now, the changes in #471 have made these calls much faster (0.3s or less), and they no longer affect the connection.

- If one device is being configured, only the DPS functions of that device will be pulled.
- If configuring multiple devices at once, all devices' DPS functions will be pulled.
- If downloading entry diagnostics, all devices' DPS functions will be pulled.
- If downloading diagnostics for a specific device, only that device’s DPS functions will be pulled.


related #457

this may affect issue where devices stops responses for no reason!

Concerns: I’m not entirely sure if the API attempts to connect to the devices to pull the DPS query. If it does, then this could affect users who block DNS/Internet access, although the impact should have been significantly reduced.