### PR TITLE
Fixes for low performance HA servers

### DIFF
--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -23,6 +23,7 @@ from .core.pytuya import (
     ContextualLogger,
     DecodeError,
     HEARTBEAT_INTERVAL,
+    TIMEOUT_CONNECT,
     SubdeviceState,
     TuyaListener,
     TuyaProtocol,
@@ -479,7 +480,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         # Delay shutdown.
         if not self.is_closing:
             try:
-                await asyncio.sleep(3 + self._device_config.sleep_time)
+                await asyncio.sleep(TIMEOUT_CONNECT + self._device_config.sleep_time)
             except asyncio.CancelledError as e:
                 self.debug(f"Shutdown entities task has been canceled: {e}", force=True)
                 return

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -138,8 +138,10 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         device_sleep = self._device_config.sleep_time
         if device_sleep > 0:
             setattr(self, "low_power", True)
-        last_update = int(time.monotonic()) - self._last_update_time
-        is_sleep = last_update < device_sleep
+	        last_update = int(time.monotonic()) - self._last_update_time
+    	    return last_update < device_sleep
+        else:
+            return False
 
         return device_sleep > 0 and is_sleep
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -138,8 +138,8 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         device_sleep = self._device_config.sleep_time
         if device_sleep > 0:
             setattr(self, "low_power", True)
-	        last_update = int(time.monotonic()) - self._last_update_time
-    	    return last_update < device_sleep
+            last_update = int(time.monotonic()) - self._last_update_time
+            return last_update < device_sleep
         else:
             return False
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -87,7 +87,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         self._subdevice_off_count: int = 0
 
         # last_update_time: Sleep timer, a device that reports the status every x seconds then goes into sleep.
-        self._last_update_time = time.time() - 5
+        self._last_update_time = time.monotonic() - 5
         self._pending_status: dict[str, dict[str, Any]] = {}
 
         self.is_closing = False
@@ -138,7 +138,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         device_sleep = self._device_config.sleep_time
         if device_sleep > 0:
             setattr(self, "low_power", True)
-        last_update = time.time() - self._last_update_time
+        last_update = int(time.monotonic()) - self._last_update_time
         is_sleep = last_update < device_sleep
 
         return device_sleep > 0 and is_sleep
@@ -498,7 +498,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         if self.is_subdevice:
             self.info(f"Sub-device disconnected due to: {exc}")
         elif hasattr(self, "low_power"):
-            m, s = divmod((int(time.time()) - self._last_update_time), 60)
+            m, s = divmod((int(time.monotonic()) - self._last_update_time), 60)
             h, m = divmod(m, 60)
             self.info(f"The device is still out of reach since: {h}h:{m}m:{s}s")
         else:
@@ -612,7 +612,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         if self._fake_gateway:
             # Fake gateways are only used to pass commands no need to update status.
             return
-        self._last_update_time = int(time.time())
+        self._last_update_time = int(time.monotonic())
 
         self._handle_event(self._status, status)
         self._status.update(status)

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -1635,12 +1635,13 @@ async def connect(
     enable_debug: bool,
     listener=None,
     port=6668,
+    timeout=TIMEOUT_CONNECT,
 ):
     """Connect to a device."""
     loop = asyncio.get_running_loop()
     on_connected = loop.create_future()
     try:
-        async with asyncio.timeout(TIMEOUT_CONNECT):
+        async with asyncio.timeout(timeout):
             _, protocol = await loop.create_connection(
                 lambda: TuyaProtocol(
                     device_id,

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -190,7 +190,7 @@ NO_PROTOCOL_HEADER_CMDS = [
 
 HEARTBEAT_INTERVAL = 8.3
 TIMEOUT_CONNECT = 5
-TIMEOUT_REPLY   = 5
+TIMEOUT_REPLY = 5
 
 # DPS that are known to be safe to use with update_dps (0x12) command
 UPDATE_DPS_WHITELIST = [18, 19, 20]  # Socket (Wi-Fi)

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -856,6 +856,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 off_devs = self.sub_devices_states.get("offline")
                 listener = self.listener and self.listener()
                 if listener is None or (on_devs is None and off_devs is None):
+                    self._sub_devs_query_task = None
                     return
                 for cid, device in listener.sub_devices.items():
                     if cid in on_devs:
@@ -866,6 +867,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                         device.subdevice_state_updated(SubdeviceState.ABSENT)
             except asyncio.CancelledError:
                 pass
+            self._sub_devs_query_task = None
 
         if (data := decoded_message.get("data")) and isinstance(data, dict):
             devs_states = self.sub_devices_states
@@ -1207,6 +1209,10 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
     async def subdevices_query(self):
         """Request a list of sub-devices and their status."""
+        # Avoid empty state parsing!
+        if self._sub_devs_query_task is not None:
+            self._sub_devs_query_task.cancel()
+            self._sub_devs_query_task = None
         # Return payload: {"online": [cid1, ...], "offline": [cid2, ...]}
         # "nearby": [cids, ...] can come in payload.
         self.sub_devices_states = {"online": [], "offline": []}

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -858,7 +858,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 off_devs = self.sub_devices_states.get("offline")
                 listener = self.listener and self.listener()
                 if listener is None or (on_devs is None and off_devs is None):
-                    self._sub_devs_query_task = None
                     return
                 for cid, device in listener.sub_devices.items():
                     if cid in on_devs:
@@ -869,7 +868,8 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                         device.subdevice_state_updated(SubdeviceState.ABSENT)
             except asyncio.CancelledError:
                 pass
-            self._sub_devs_query_task = None
+            finally:
+                self._sub_devs_query_task = None
 
         if (data := decoded_message.get("data")) and isinstance(data, dict):
             devs_states = self.sub_devices_states

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -1635,7 +1635,6 @@ async def connect(
     enable_debug: bool,
     listener=None,
     port=6668,
-    timeout=TIMEOUT_REPLY,
 ):
     """Connect to a device."""
     loop = asyncio.get_running_loop()
@@ -1667,5 +1666,4 @@ async def connect(
     except:
         raise Exception(f"The host refused to connect")
 
-    await asyncio.wait_for(on_connected, timeout=timeout)
     return protocol

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -769,7 +769,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         local_key: str,
         protocol_version: float,
         enable_debug: bool,
-        on_connected: asyncio.Future,
         listener: TuyaListener,
     ):
         """
@@ -803,7 +802,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         self.transport = None
         self.listener = weakref.ref(listener)
         self.dispatcher = self._setup_dispatcher()
-        self.on_connected = on_connected
         self.heartbeater: asyncio.Task | None = None
         self._sub_devs_query_task: asyncio.Task | None = None
         self.dps_cache = {}
@@ -936,7 +934,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
     def connection_made(self, transport):
         """Did connect to the device."""
         self.transport = transport
-        self.on_connected.set_result(True)
 
     def keep_alive(self, is_gateway: bool = False):
         """
@@ -1639,7 +1636,6 @@ async def connect(
 ):
     """Connect to a device."""
     loop = asyncio.get_running_loop()
-    on_connected = loop.create_future()
     try:
         async with asyncio.timeout(timeout):
             _, protocol = await loop.create_connection(
@@ -1648,7 +1644,6 @@ async def connect(
                     local_key,
                     protocol_version,
                     enable_debug,
-                    on_connected,
                     listener or EmptyListener(),
                 ),
                 address,

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -189,6 +189,8 @@ NO_PROTOCOL_HEADER_CMDS = [
 ]
 
 HEARTBEAT_INTERVAL = 8.3
+TIMEOUT_CONNECT = 5
+TIMEOUT_REPLY   = 5
 
 # DPS that are known to be safe to use with update_dps (0x12) command
 UPDATE_DPS_WHITELIST = [18, 19, 20]  # Socket (Wi-Fi)
@@ -1636,13 +1638,13 @@ async def connect(
     enable_debug: bool,
     listener=None,
     port=6668,
-    timeout=5,
+    timeout=TIMEOUT_REPLY,
 ):
     """Connect to a device."""
     loop = asyncio.get_running_loop()
     on_connected = loop.create_future()
     try:
-        async with asyncio.timeout(3):
+        async with asyncio.timeout(TIMEOUT_CONNECT):
             _, protocol = await loop.create_connection(
                 lambda: TuyaProtocol(
                     device_id,

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -277,7 +277,6 @@ class ContextualLogger:
         self._logger = None
         self._enable_debug = False
 
-        self._reset_warning = int(time.time())
         self._last_warning = ""
 
     def set_logger(self, logger, device_id, enable_debug=False, name=None):
@@ -1012,7 +1011,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             while self.last_command_sent < 0.050:
                 await asyncio.sleep(0.010)
 
-            self._last_command_sent = time.time()
+            self._last_command_sent = time.monotonic()
             self.transport.write(data)
 
     async def close(self):
@@ -1621,7 +1620,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
     @property
     def last_command_sent(self):
         """Return last command sent by seconds"""
-        return time.time() - self._last_command_sent
+        return time.monotonic() - self._last_command_sent
 
     def __repr__(self):
         """Return internal string representation of object."""


### PR DESCRIPTION
I'm yet to find time to update to HA Core 2025.x, and to incorporate your many changes to LocalTuya :(

Meanwhile, I ran many tests with low performance HA server, and, as the result, these are related fixes. I suggest to read commit by commit: they all should be understandable. Yes, I saw all the fixed misbehaviors in real life!

Yes, I saw successful connects after 4.5 seconds. But, regardless, making `TIMEOUT_CONNECT` (was 3) less than `TIMEOUT_REPLY` has not much sense: usually connect is even longer process.

I've changed `HEARTBEAT_INTERVAL` to 8.3 because 83 is a big enough prime number. Making periodic tasks with periods of prime numbers decrease the chance of "crowded" periodic events across the whole system.