### PR TITLE
Better handling of absent subdevices

### DIFF
--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -653,10 +653,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                     self.disconnected("Device is absent")
                 # Can be >2 subsequent payloads per one request
                 elif delay > HEARTBEAT_INTERVAL:
-                    self.debug(f"Sub-device is absent for {round(delay,3)}s")
-            else:
-                # Can be false alarm, do nothing!
-                pass
+                    self.debug(f"Sub-device is absent for {delay:.03f}s")
             return
         elif old_state == SubdeviceState.ABSENT and not self.connected:
             self.info(f"Sub-device is back {node_id}")

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -324,11 +324,11 @@ class TuyaDevice(TuyaListener, ContextualLogger):
 
         # If not connected try to handle the errors.
         if not self.connected and not self.is_closing:
+            if update_localkey:
+                # Check if the cloud device info has changed!
+                await self._update_local_key()
             if self._task_reconnect is None:
                 self._task_reconnect = asyncio.create_task(self._async_reconnect())
-            if update_localkey:
-                # Check if the cloud device info has changed!.
-                await self._update_local_key()
 
         self._task_connect = None
 

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -137,7 +137,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         """Return whether the device is sleep or not."""
         if (device_sleep := self._device_config.sleep_time) > 0:
             setattr(self, "low_power", True)
-            last_update = int(time.monotonic()) - self._last_update_time
+            last_update = time.monotonic() - self._last_update_time
             return last_update < device_sleep
 
         return False
@@ -496,7 +496,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         if self.is_subdevice:
             self.info(f"Sub-device disconnected due to: {exc}")
         elif hasattr(self, "low_power"):
-            m, s = divmod((int(time.monotonic()) - self._last_update_time), 60)
+            m, s = divmod((int(time.monotonic() - self._last_update_time)), 60)
             h, m = divmod(m, 60)
             self.info(f"The device is still out of reach since: {h}h:{m}m:{s}s")
         else:
@@ -601,7 +601,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             # Fake gateways are only used to pass commands no need to update status.
             return
 
-        self._last_update_time = int(time.monotonic())
+        self._last_update_time = time.monotonic()
         self._handle_event(self._status, status)
         self._status.update(status)
         self._dispatch_status()

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -651,10 +651,11 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                 if delay >= 2 * HEARTBEAT_INTERVAL:
                     self._subdevice_off_count = 0
                     self.disconnected("Device is absent")
-                else:
+                # Can be >2 subsequent payloads per one request
+                elif delay > HEARTBEAT_INTERVAL:
                     self.debug(f"Sub-device is absent for {round(delay,3)}s")
             else:
-                # Can be false alarm! Do nothing!
+                # Can be false alarm, do nothing!
                 pass
             return
         elif old_state == SubdeviceState.ABSENT and not self.connected:

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -509,6 +509,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         if self._entry.data.get(CONF_NO_CLOUD, True):
             return self.info("Ensure that localkey hasn't changed and it's correct")
 
+        self.info(f"Trying to update local-key...")
         dev_id = self._device_config.id
         cloud_api = self._hass_entry.cloud_data
         await cloud_api.async_get_devices_list(force_update=True)

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -665,7 +665,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         off_count = self._subdevice_off_count
         self._subdevice_off_count = 0 if is_online else off_count + 1
         # For sub-devices, the last time it is known as not absent
-        self._last_update_time = int(time.monotonic())
+        self._last_update_time = time.monotonic()
 
         if is_online:
             return self.info(f"Sub-device is online {node_id}") if off_count else None

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -648,7 +648,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         if state == SubdeviceState.ABSENT:
             if old_state == state:
                 delay = time.monotonic() - self._last_update_time
-                if delay >= 2 * HEARTBEAT_INTERVAL:
+                if delay >= (HEARTBEAT_INTERVAL * 2):
                     self._subdevice_off_count = 0
                     self.disconnected("Device is absent")
                 # Can be >2 subsequent payloads per one request

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -174,8 +174,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         for subdevice in self.sub_devices.values():
             if not self.connected or self.is_closing:
                 break
-            if subdevice.subdevice_state != SubdeviceState.ABSENT:
-                await subdevice.async_connect()
+            await subdevice.async_connect()
 
     async def _make_connection(self):
         """Subscribe localtuya entity events."""
@@ -645,17 +644,26 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         self.subdevice_state = state
 
         # This will trigger if state is absent twice.
-        if old_state == state and state == SubdeviceState.ABSENT:
-            self._subdevice_off_count = 0
-            return self.disconnected("Device is absent")
-        elif state == SubdeviceState.ABSENT:
-            return self.info(f"Sub-device is absent {node_id}")
-        elif old_state == SubdeviceState.ABSENT:
+        if state == SubdeviceState.ABSENT:
+            if old_state == state:
+                delay = time.monotonic() - self._last_update_time
+                if delay >= 2 * HEARTBEAT_INTERVAL:
+                    self._subdevice_off_count = 0
+                    self.disconnected("Device is absent")
+                else:
+                    self.debug(f"Sub-device is absent for {round(delay,3)}s")
+            else:
+                # Can be false alarm! Do nothing!
+                pass
+            return
+        elif old_state == SubdeviceState.ABSENT and not self.connected:
             self.info(f"Sub-device is back {node_id}")
 
         is_online = state == SubdeviceState.ONLINE
         off_count = self._subdevice_off_count
         self._subdevice_off_count = 0 if is_online else off_count + 1
+        # For sub-devices, the last time it is known as not absent
+        self._last_update_time = int(time.monotonic())
 
         if is_online:
             return self.info(f"Sub-device is online {node_id}") if off_count else None

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -942,8 +942,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                     self.debug("Stopped heartbeat loop")
                     break
                 except asyncio.TimeoutError:
-                    if hasattr(self.listener and self.listener(), "low_power"):
-                        break
                     fail_attempt += 1
                     if fail_attempt >= 2:
                         self.debug("Heartbeat failed due to timeout, disconnecting")

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -847,7 +847,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
         async def _action(on_devs, off_devs):
             try:
-                self.debug(f"Sub-Devices States Update: on_devs={on_devs} off_devs={off_devs}")
+                self.debug(
+                    f"Sub-Devices States Update: on_devs={on_devs} off_devs={off_devs}"
+                )
                 listener = self.listener and self.listener()
                 if listener is None:
                     return

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -847,9 +847,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
         async def _action(on_devs, off_devs):
             try:
-                self.debug(
-                    f"Sub-Devices States Update: on_devs={on_devs} off_devs={off_devs}"
-                )
+                self.debug(f"Sub-Devices States Update: {on_devs=} {off_devs=}")
                 listener = self.listener and self.listener()
                 if listener is None:
                     return

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -805,7 +805,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         self.heartbeater: asyncio.Task | None = None
         self._sub_devs_query_task: asyncio.Task | None = None
         self.dps_cache = {}
-        self.sub_devices_states = {"online": [], "offline": []}
         self.local_nonce = b"0123456789abcdef"  # not-so-random random key
         self.remote_nonce = b""
         self.dps_whitelist = UPDATE_DPS_WHITELIST
@@ -846,15 +845,11 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         Message: {"online": [cids, ...], "offline": [cids, ...], "nearby": [cids, ...]}
         """
 
-        async def _action():
+        async def _action(on_devs, off_devs):
             try:
-                await asyncio.sleep(2)
-
-                self.debug(f"Sub-Devices States Update: {self.sub_devices_states}")
-                on_devs = self.sub_devices_states.get("online")
-                off_devs = self.sub_devices_states.get("offline")
+                self.debug(f"Sub-Devices States Update: on_devs={on_devs} off_devs={off_devs}")
                 listener = self.listener and self.listener()
-                if listener is None or (on_devs is None and off_devs is None):
+                if listener is None:
                     return
                 for cid, device in listener.sub_devices.items():
                     if cid in on_devs:
@@ -862,6 +857,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                     elif cid in off_devs:
                         device.subdevice_state_updated(SubdeviceState.OFFLINE)
                     else:
+                        # ABSENT detection is weak, because, with many sub-devices,
+                        # the gateway provides them all in more than 1 reply. This
+                        # should be taken into account in device.subdevice_state_updated()
                         device.subdevice_state_updated(SubdeviceState.ABSENT)
             except asyncio.CancelledError:
                 pass
@@ -869,22 +867,10 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 self._sub_devs_query_task = None
 
         if (data := decoded_message.get("data")) and isinstance(data, dict):
-            devs_states = self.sub_devices_states
-            updated_states = {}
-
-            cached_on_devs = devs_states.get("online", [])
-            cached_off_devs = devs_states.get("offline", [])
-
             on_devs, off_devs = data.get("online", []), data.get("offline", [])
-
-            updated_states["online"] = list(set(cached_on_devs + on_devs))
-            updated_states["offline"] = list(set(cached_off_devs + off_devs))
-
-            if self._sub_devs_query_task is not None:
-                self._sub_devs_query_task.cancel()
-
-            self.sub_devices_states = updated_states
-            self._sub_devs_query_task = self.loop.create_task(_action())
+            self._sub_devs_query_task = self.loop.create_task(
+                _action(on_devs, off_devs)
+            )
 
     def _setup_dispatcher(self) -> MessageDispatcher:
         def _status_update(msg, ack=False):
@@ -1205,13 +1191,8 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
     async def subdevices_query(self):
         """Request a list of sub-devices and their status."""
-        # Avoid empty state parsing!
-        if self._sub_devs_query_task is not None:
-            self._sub_devs_query_task.cancel()
-            self._sub_devs_query_task = None
         # Return payload: {"online": [cid1, ...], "offline": [cid2, ...]}
         # "nearby": [cids, ...] can come in payload.
-        self.sub_devices_states = {"online": [], "offline": []}
         payload = self._generate_payload(
             LAN_EXT_STREAM, rawData={"cids": []}, reqType="subdev_online_stat_query"
         )

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -942,6 +942,8 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                     self.debug("Stopped heartbeat loop")
                     break
                 except asyncio.TimeoutError:
+                    if hasattr(self.listener and self.listener(), "low_power"):
+                        break
                     fail_attempt += 1
                     if fail_attempt >= 2:
                         self.debug("Heartbeat failed due to timeout, disconnecting")


### PR DESCRIPTION
Weak detection of absent sub-devices instead of fuzzy logic with delays:

The lists of offline/online subdevices are parsed and handled immediatelly. A device is considered as absent if it was not mentioned in either list, nor its DPs were updated, for at least two heartbeat periods.

`_connect_subdevices()` no longer checks for `SubdeviceState.ABSENT` because it is now weak state. It does not hurt to try to connect to a subdevice that may be absent anyway.

`pass` operator is intentional: to prevent an attempt to handle this case by a further developer who didn't read the comment in the pytuya.py.

Tested and proved to work.