### PR TITLE
Add a basic dev container and contributing doc

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+    "image":"mcr.microsoft.com/devcontainers/universal:2",
+    "postCreateCommand": "pip install -r requirements_test.txt"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Quick start
+
+Fork the repository, and start a new codespace via the github UI.
+
+Read the [manual](https://xzetsubou.github.io/hass-localtuya/).
+
+## Manual setup
+
+As above.
+
+Python 3.12 or higher.
+
+`pip install -r requirements_test.txt`
+
+Validate your installation with:
+
+`pytest`
+
+## Contributing
+
+- Run `black` and `codespell` to ensure your code passes CI.
+- Bonus points for adding test coverage.
+- If you utilise an AI agent, please disclose in your pull request. (They can be very useful, but also get things very wrong some times)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Fork the repository, and start a new codespace via the github UI.
 
+![image](https://github.com/user-attachments/assets/aee1e022-b607-4cf9-8bb2-d5ba5ec56232)
+
 Read the [manual](https://xzetsubou.github.io/hass-localtuya/).
 
 ## Manual setup
@@ -21,3 +23,4 @@ Validate your installation with:
 - Run `black` and `codespell` to ensure your code passes CI.
 - Bonus points for adding test coverage.
 - If you utilise an AI agent, please disclose in your pull request. (They can be very useful, but also get things very wrong some times)
+- If your PR is a work in progress, has failing tests, or something you aren't sure about, mark as draft.


### PR DESCRIPTION
Adds a github codespaces 'quick start' approach, which is handy when you don't have a local environment.

Adds some suggested contributing guidelines, which may or may not be useful.