### PR TITLE
Add support for sending raw IR codes via Tuya remote

### DIFF
--- a/custom_components/localtuya/remote.py
+++ b/custom_components/localtuya/remote.py
@@ -186,6 +186,20 @@ class LocalTuyaRemote(LocalTuyaEntity, RemoteEntity):
         repeats: int = kwargs.get(ATTR_NUM_REPEATS)
         repeats_delay: float = kwargs.get(ATTR_DELAY_SECS)
 
+        # If device is not specified, treat commands as raw codes
+        if not device:
+            for base64_code in commands:
+                if repeats:
+                    current_repeat = 0
+                    while current_repeat < repeats:
+                        await self.send_signal(ControlMode.SEND_IR, base64_code)
+                        if repeats_delay:
+                            await asyncio.sleep(repeats_delay)
+                        current_repeat += 1
+                    continue
+                await self.send_signal(ControlMode.SEND_IR, base64_code)
+            return
+
         for req in [device, commands]:
             if not req:
                 raise ServiceValidationError("Missing required fields")
@@ -193,13 +207,6 @@ class LocalTuyaRemote(LocalTuyaEntity, RemoteEntity):
         if not self._storage_loaded:
             await self._async_load_storage()
 
-        # base64_code = ""
-        # if base64_code is None:
-        #     option_value = ""
-        #     _LOGGER.debug("Sending Option: -> " + option_value)
-
-        #     pulses = self.pronto_to_pulses(option_value)
-        #     base64_code = "1" + self.pulses_to_base64(pulses)
         for command in commands:
             code = self._get_code(device, command)
 


### PR DESCRIPTION
Adding support for sending raw IR codes (when device is not specified)
in order to enable other components like SmartIR to send codes they store on their end.
This allows for a very nice UI and easier management of large number of codes for different AC brands, as supported by SmartIR.

Tested on my machine and works nicely. 

This resolves many long standing request for integration between SmartIR and local-tuya.