### PR TITLE
perf: ignore fire event if no listeners

### DIFF
--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -561,6 +561,8 @@ class TuyaDevice(TuyaListener, ContextualLogger):
 
         def fire_event(event, data: dict):
             """Fire events."""
+            if f"localtuya_{event}" not in self.hass.bus.async_listeners():
+                return self.error(f"No listeners for event: {event}")
             event_data = {CONF_DEVICE_ID: self.id, **data}
             if len(event_data) > 1:
                 self.hass.bus.async_fire(f"localtuya_{event}", event_data)

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -562,7 +562,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         def fire_event(event, data: dict):
             """Fire events."""
             if f"localtuya_{event}" not in self.hass.bus.async_listeners():
-                return self.error(f"No listeners for event: {event}")
+                return
             event_data = {CONF_DEVICE_ID: self.id, **data}
             if len(event_data) > 1:
                 self.hass.bus.async_fire(f"localtuya_{event}", event_data)

--- a/custom_components/localtuya/manifest.json
+++ b/custom_components/localtuya/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/xZetsubou/hass-localtuya/issues",
   "requirements": [],
-  "version": "2025.8.0"
+  "version": "2025.10.0"
 }


### PR DESCRIPTION
This is just workaround, for those who doesn't use the "events", events now will be ignored if no-one listen to it.

related to #517