### PR TITLE
refactor(vacuum): Remove battery attrbiute

### DIFF
--- a/custom_components/localtuya/core/ha_entities/sensors.py
+++ b/custom_components/localtuya/core/ha_entities/sensors.py
@@ -1392,6 +1392,14 @@ SENSORS: dict[str, tuple[LocalTuyaEntity, ...]] = {
             icon="mdi:ticket-percent-outline",
             state_class=SensorStateClass.MEASUREMENT,
         ),
+        LocalTuyaEntity(
+            id=(DPCode.ELECTRICITY_LEFT, DPCode.RESIDUAL_ELECTRICITY),
+            name="Battery",
+            device_class=SensorDeviceClass.BATTERY,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        *BATTERY_SENSORS,
     ),
     # Curtain
     # https://developer.tuya.com/en/docs/iot/s?id=K9gf48qy7wkre

--- a/custom_components/localtuya/core/ha_entities/vacuums.py
+++ b/custom_components/localtuya/core/ha_entities/vacuums.py
@@ -68,11 +68,6 @@ VACUUMS: dict[str, tuple[LocalTuyaEntity, ...]] = {
             id=DPCode.STATUS,
             icon="mdi:robot-vacuum",
             powergo_dp=(DPCode.POWER_GO, DPCode.POWER, DPCode.SWITCH),
-            battery_dp=(
-                DPCode.BATTERY_PERCENTAGE,
-                DPCode.ELECTRICITY_LEFT,
-                DPCode.RESIDUAL_ELECTRICITY,
-            ),
             mode_dp=DPCode.MODE,
             fan_speed_dp=DPCode.SUCTION,
             pause_dp=DPCode.PAUSE,

--- a/custom_components/localtuya/vacuum.py
+++ b/custom_components/localtuya/vacuum.py
@@ -14,7 +14,6 @@ from homeassistant.components.vacuum import (
 
 from .entity import LocalTuyaEntity, async_setup_entry
 from .const import (
-    CONF_BATTERY_DP,
     CONF_CLEAN_AREA_DP,
     CONF_CLEAN_RECORD_DP,
     CONF_CLEAN_TIME_DP,
@@ -65,7 +64,6 @@ def flow_schema(dps):
         vol.Optional(CONF_PAUSED_STATE, default=DEFAULT_PAUSED_STATE): str,
         vol.Optional(CONF_STOP_STATUS, default=DEFAULT_STOP_STATUS): str,
         vol.Optional(CONF_PAUSE_DP): col_to_select(dps, is_dps=True),
-        vol.Optional(CONF_BATTERY_DP): col_to_select(dps, is_dps=True),
         vol.Optional(CONF_MODE_DP): col_to_select(dps, is_dps=True),
         vol.Optional(CONF_MODES, default=DEFAULT_MODES): str,
         vol.Optional(CONF_RETURN_MODE, default=DEFAULT_RETURN_MODE): str,
@@ -86,7 +84,6 @@ class LocalTuyaVacuum(LocalTuyaEntity, StateVacuumEntity):
         """Initialize a new LocalTuyaVacuum."""
         super().__init__(device, config_entry, switchid, _LOGGER, **kwargs)
         self._state = None
-        self._battery_level = None
         self._attrs = {}
 
         self._idle_status_list = []
@@ -136,8 +133,6 @@ class LocalTuyaVacuum(LocalTuyaEntity, StateVacuumEntity):
             supported_features |= VacuumEntityFeature.RETURN_HOME
         if self.has_config(CONF_FAN_SPEED_DP):
             supported_features |= VacuumEntityFeature.FAN_SPEED
-        if self.has_config(CONF_BATTERY_DP):
-            supported_features |= VacuumEntityFeature.BATTERY
         if self.has_config(CONF_LOCATE_DP):
             supported_features |= VacuumEntityFeature.LOCATE
 
@@ -147,11 +142,6 @@ class LocalTuyaVacuum(LocalTuyaEntity, StateVacuumEntity):
     def activity(self) -> VacuumActivity | None:
         """Return the vacuum state."""
         return self._state
-
-    @property
-    def battery_level(self):
-        """Return the current battery level."""
-        return self._battery_level
 
     @property
     def extra_state_attributes(self):
@@ -238,9 +228,6 @@ class LocalTuyaVacuum(LocalTuyaEntity, StateVacuumEntity):
             self._state = VacuumActivity.PAUSED
         else:
             self._state = VacuumActivity.CLEANING
-
-        if self.has_config(CONF_BATTERY_DP):
-            self._battery_level = self.dp_value(CONF_BATTERY_DP)
 
         self._cleaning_mode = ""
         if self.has_config(CONF_MODES):

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -22,7 +22,6 @@ CONFIG = {
                 "paused_state": "paused",
                 "stop_status": "standby",
                 "pause_dp": "101",
-                "battery_dp": "6",
                 "mode_dp": "3",
                 "modes": "smart,zone,pose,part,chargego,wallfollow,selectroom",
                 "return_mode": "chargego",
@@ -46,7 +45,6 @@ DPS_STATUS = {
     "2": True,  # powergo_dp
     "3": "smart",  # mode_dp
     "5": "cleaning",  # id - state
-    "6": 45,  # battery_dp
     "13": False,  # locate_dp
     "14": "quiet",  # fan_speed_dp
     "16": 0,  # clean_area_dp
@@ -70,7 +68,6 @@ async def test_vacuum():
     status = DPS_STATUS.copy()
     device.status_updated(status)
     assert entity_1.state == VacuumActivity.CLEANING
-    assert entity_1.battery_level == 45
     assert entity_1.fan_speed == "quiet"
     assert status[entity_1_cfg[CONF_MODE_DP]] in entity_1._modes_list
 


### PR DESCRIPTION
Home Assistant no longer has battery attribute in Vacuum entity, instead now user shall create seprated sensor entity for battery.

related: #706

REF: https://developers.home-assistant.io/blog/2025/07/02/vacuum-battery-properties-deprecated?_highlight=vacuum