### PR TITLE
Fix typo in HA entities

### DIFF
--- a/custom_components/localtuya/core/ha_entities/sensors.py
+++ b/custom_components/localtuya/core/ha_entities/sensors.py
@@ -1215,7 +1215,7 @@ SENSORS: dict[str, tuple[LocalTuyaEntity, ...]] = {
         ## PHASE X Are probably encrypted values. since it duplicated it probably raw dict data.
         LocalTuyaEntity(
             id=DPCode.PHASE_A,
-            name="Phase C Current",
+            name="Phase A",
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
         LocalTuyaEntity(


### PR DESCRIPTION
Entity id "phase_a" should have the entity name "Phase A".

Fixes bug where Sensors are prefixed with "Phase C Current" instead of "Phase A" e.g. I have
"Phase C Current" AND
"Phase C Current Current" 

Btw, thank a liar (Claude) for this fix.