### PR TITLE
🚀 Add support for device templates and docs

### DIFF
--- a/custom_components/localtuya/templates/htw_smart_water_heater.yaml
+++ b/custom_components/localtuya/templates/htw_smart_water_heater.yaml
@@ -1,0 +1,103 @@
+# HTW Smart Plus Water Heater
+# Models: HTW-TV-030SMPLUS, HTW-TV-050SMPLUS, HTW-TV-080SMPLUS, HTW-TV-100SMPLUS
+# https://htwspain.com/pt/água-quente-pt/frasco-termico-smart-plus/
+- water_heater:
+      current_temperature_dp: "10"
+      entity_category: None
+      friendly_name: Water Heater
+      icon: ""
+      id: "1"
+      max_temperature: 75.0
+      min_temperature: 35.0
+      mode_dp: "2"
+      modes:
+          eco: ECO
+          highwarm: Anti-Bacteria
+          jiheat: Instant Heating
+          manmenu: Smart
+      platform: water_heater
+      precision: "1"
+      target_precision: "1"
+      target_temperature_dp: "9"
+      temperature_unit: celsius
+- switch:
+      device_class: switch
+      entity_category: None
+      friendly_name: Power
+      icon: ""
+      id: "1"
+      is_passive_entity: false
+      platform: switch
+      restore_on_reconnect: false
+- sensor:
+      device_class: energy
+      entity_category: None
+      friendly_name: Energy Today
+      icon: ""
+      id: "12"
+      platform: sensor
+      state_class: total_increasing
+      unit_of_measurement: kWh
+- select:
+      dps_default_value: Instant Heating
+      entity_category: None
+      friendly_name: Mode
+      icon: ""
+      id: "2"
+      is_passive_entity: false
+      platform: select
+      restore_on_reconnect: false
+      select_options:
+          eco: ECO
+          highwarm: Anti-Bacteria
+          jiheat: Instant Heating
+          manmenu: Smart
+- sensor:
+      device_class: temperature
+      entity_category: None
+      friendly_name: Current Temperature
+      icon: ""
+      id: "10"
+      platform: sensor
+      unit_of_measurement: ºC
+- sensor:
+      device_class: temperature
+      entity_category: None
+      friendly_name: Target Temperature
+      icon: ""
+      id: "9"
+      platform: sensor
+      state_class: measurement
+      unit_of_measurement: ºC
+- sensor:
+      device_class: water
+      entity_category: None
+      friendly_name: Surplus Water
+      icon: ""
+      id: "14"
+      platform: sensor
+      state_class: measurement
+      unit_of_measurement: "%"
+- sensor:
+      device_class: enum
+      entity_category: None
+      friendly_name: Status
+      icon: ""
+      id: "13"
+      platform: sensor
+- sensor:
+      entity_category: None
+      friendly_name: Countdown Left
+      icon: ""
+      id: "19"
+      platform: sensor
+      unit_of_measurement: Hours
+- binary_sensor:
+      device_class: problem
+      entity_category: diagnostic
+      friendly_name: Fault
+      icon: ""
+      id: "20"
+      platform: binary_sensor
+      reset_timer: 0.0
+      state_on: true,1,pir,on

--- a/documentation/docs/contributing_templates.md
+++ b/documentation/docs/contributing_templates.md
@@ -1,0 +1,72 @@
+# Contributing Device Templates
+
+Templates are YAML files in `custom_components/localtuya/templates/` that describe a device's entity configuration. Users can import them when adding a new device instead of configuring entities manually.
+
+For existing templates, see the [Templates Catalog](templates_catalog.md).
+
+---
+
+## Creating a Template
+
+### Export from a configured device (Recommended) { #export }
+
+1. Go to **Settings → Devices & Services → LocalTuya → Configure**
+2. Select **Reconfigure existing device**
+3. Choose the device you want to export
+4. Check **Save entity configuration as template**
+5. Submit
+
+The template will be saved to `custom_components/localtuya/templates/`.
+
+### Write YAML manually
+
+You can write a template by hand. See the example below and the [Templates Catalog](templates_catalog.md) for reference.
+
+!!! warning "There is no validation for manually written templates. Double-check your DP IDs and platform settings."
+
+example "2-Gang Switch template"
+
+```yaml
+- switch:
+    id: "1"
+    friendly_name: "Switch 1"
+    entity_category: None
+    is_passive_entity: false
+    platform: "switch"
+
+- switch:
+    id: "2"
+    friendly_name: "Switch 2"
+    entity_category: None
+    is_passive_entity: false
+    platform: "switch"
+```
+
+## File Naming
+
+Lowercase, underscore-separated. Include device type and optionally brand/model:
+
+- `2g_switch.yaml`
+- `zemismart_curtain_motor.yaml`
+- `rgbw_bulb_music.yaml`
+
+---
+
+## Submitting a Pull Request
+
+1. **Fork** the [repository](https://github.com/xZetsubou/hass-localtuya){target="_blank"}
+2. Add your template YAML to `custom_components/localtuya/templates/`
+3. Create a device markdown file in `documentation/docs/devices/` (see existing files for format)
+4. Add a row to the **Available Templates** table in `templates_catalog.md` linking to your device page
+5. Open a PR with: device name/model, category, entities included, and protocol version
+
+### Before submitting
+
+- Template tested — re-import it on a clean device to confirm it works
+- No sensitive data (`local_key`, `device_id`, `ip`) in the file
+- Friendly names are generic (e.g., "Switch 1" not "My Kitchen Light")
+- Catalog page updated
+
+!!! danger "Never share your `local_key` or `device_id` publicly."
+
+!!! info "Templates load at HA startup. A restart is required after adding a new file."

--- a/documentation/docs/devices/htw_smart_water_heater.md
+++ b/documentation/docs/devices/htw_smart_water_heater.md
@@ -1,0 +1,30 @@
+# HTW Smart Plus Water Heater
+
+**Brand:** HTW | **Category:** Water Heater
+
+**Models:** `HTW-TV-030SMPLUS`, `HTW-TV-050SMPLUS`, `HTW-TV-080SMPLUS`, `HTW-TV-100SMPLUS`
+
+**Product page:** [htwspain.com](https://htwspain.com/pt/%C3%A1gua-quente-pt/frasco-termico-smart-plus/){target="_blank"}
+
+---
+
+## Entities
+
+| # | Platform | DP ID | Name | Device Class |
+|---|---|---|---|---|
+| 1 | `water_heater` | 1 | Water Heater | — |
+| 2 | `switch` | 1 | Power | switch |
+| 3 | `sensor` | 12 | Energy Today | energy |
+| 4 | `select` | 2 | Mode | — |
+| 5 | `sensor` | 10 | Current Temperature | temperature |
+| 6 | `sensor` | 9 | Target Temperature | temperature |
+| 7 | `sensor` | 14 | Surplus Water | water |
+| 8 | `sensor` | 13 | Status | enum |
+| 9 | `sensor` | 19 | Countdown Left | — |
+| 10 | `binary_sensor` | 20 | Fault | problem |
+
+**Modes:** ECO, Anti-Bacteria, Instant Heating, Smart
+
+---
+
+[:material-download: Download template](https://github.com/xZetsubou/hass-localtuya/blob/master/custom_components/localtuya/templates/htw_smart_water_heater.yaml){target="_blank" .md-button}

--- a/documentation/docs/templates_catalog.md
+++ b/documentation/docs/templates_catalog.md
@@ -1,0 +1,28 @@
+# Device Templates Catalog
+
+Browse community-contributed device templates for LocalTuya. Use these templates to quickly configure your Tuya devices without manual DP mapping.
+
+!!! tip "How to use a template"
+    1. Download the YAML file and place it in `custom_components/localtuya/templates/`
+    2. Restart Home Assistant
+    3. When adding a new device, select **Use saved template** in the config flow
+    4. Choose the template from the list
+
+    Want to contribute your own? See the [Contributing Guide](contributing_templates.md).
+
+---
+
+## Available Templates
+
+| Device | Brand | Category | Models |
+|---|---|---|---|
+| [HTW Smart Plus Water Heater](devices/htw_smart_water_heater.md) | HTW | :material-water-boiler: Water Heater | HTW-TV-030SMPLUS, HTW-TV-050SMPLUS, HTW-TV-080SMPLUS, HTW-TV-100SMPLUS |
+
+---
+
+## Adding Your Template to This Page
+
+When you [contribute a template](contributing_templates.md), please also update this page in your Pull Request:
+
+1. Create a new markdown file in `docs/devices/` for your device
+2. Add a row to the **Available Templates** table above with the device name linking to your page

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: Localtuya
 repo_url: https://github.com/xZetsubou/hass-localtuya/
 edit_uri: blob/master/documentation/docs/
-copyright: Copyright © Bander xZetsubou 
+copyright: Copyright © Bander xZetsubou
 
 theme:
-  name: 'material'
+  name: "material"
   features:
     - content.action.edit
     - content.code.annotate
@@ -16,24 +16,37 @@ theme:
     scheme: slate
     primary: teal
     accent: teal
+  icon:
+    tag:
+      water_heater: material/water-boiler
+      switch: material/light-switch
+      light: material/lightbulb
+      cover: material/blinds
+      climate: material/thermostat
+      fan: material/fan
+      sensor: material/thermometer
 
 nav:
   - index.md
   - ha_events.md
   - ha_services.md
   - Guides:
-    - Usage:
-      - usage/installation.md
-      - usage/configure_add_device.md
-      - usage/configure_edit_device.md
-      - usage/devices_delete.md
-    - cloud_api.md
+      - Usage:
+          - usage/installation.md
+          - usage/configure_add_device.md
+          - usage/configure_edit_device.md
+          - usage/devices_delete.md
+      - cloud_api.md
   - Development:
-    - auto_configure.md
+      - auto_configure.md
+  - Templates:
+      - templates_catalog.md
+      - contributing_templates.md
+      - Devices:
+          - devices/htw_smart_water_heater.md
   - Others:
       - faq/index.md
       - report_issue.md
-
 
 extra_css:
   - style/extra.css


### PR DESCRIPTION
# 📃 Description

This PR updates documentation structure to add support for a device template index, enabling users to submit working device examples.

- Add a catalog page for available templates with instructions.
- Create documentation for contributing device templates.
- Introduce a new YAML template for the HTW Smart Plus Water Heater.