### PR TITLE
fix(coordinator): detect and recover from zombie connections

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -156,8 +156,10 @@ async def async_setup(hass: HomeAssistant, config: dict):
         # settings triggers a reload of the config entry, which tears down the device
         # so no need to connect in that case.
         if updated:
-            _LOGGER.debug(
-                "Updating keys for device %s: %s %s", device_id, device_ip, product_key
+            _LOGGER.warning(
+                "Discovery: device %s changed (IP: %s, product_key: %s), "
+                "triggering integration reload",
+                device_id, device_ip, product_key,
             )
             new_data[ATTR_UPDATED_AT] = str(int(time.time() * 1000))
             hass.config_entries.async_update_entry(entry, data=new_data)

--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -59,6 +59,8 @@ SERVICE_SET_DP_SCHEMA = vol.Schema(
     }
 )
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the LocalTuya integration component."""

--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -159,7 +159,9 @@ async def async_setup(hass: HomeAssistant, config: dict):
             _LOGGER.warning(
                 "Discovery: device %s changed (IP: %s, product_key: %s), "
                 "triggering integration reload",
-                device_id, device_ip, product_key,
+                device_id,
+                device_ip,
+                product_key,
             )
             new_data[ATTR_UPDATED_AT] = str(int(time.time() * 1000))
             hass.config_entries.async_update_entry(entry, data=new_data)

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -710,7 +710,13 @@ class LocalTuyaOptionsFlowHandler(OptionsFlow):
         schema = vol.Schema(
             {vol.Required(TEMPLATES): col_to_select(templates_list, custom_value=True)}
         )
-        return self.async_show_form(step_id="choose_template", data_schema=schema)
+        return self.async_show_form(
+            step_id="choose_template",
+            data_schema=schema,
+            description_placeholders={
+                "templates_url": "https://github.com/xZetsubou/hass-localtuya/discussions/13"
+            },
+        )
 
     async def async_step_entity(self, user_input=None):
         """Manage entity settings."""

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -802,6 +802,16 @@ class LocalTuyaOptionsFlowHandler(OptionsFlow):
                 "platform": self.selected_platform,
             }
 
+        placeholders.update(
+            {
+                "hvac_modes_url": "https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes",
+                "hvac_actions_url": "https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action",
+                "alarm_states_url": "https://developers.home-assistant.io/docs/core/entity/alarm-control-panel/#states",
+                "device_class_url": "https://www.home-assistant.io/integrations/homeassistant/#device-class",
+                "state_class_url": "https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes",
+            }
+        )
+
         return self.async_show_form(
             step_id="configure_entity",
             data_schema=schema,

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -581,9 +581,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             return
         elapsed = time.monotonic() - self._last_data_time
         if elapsed >= STALE_DATA_TIMEOUT:
-            self.warning(
-                "No data received for %.0fs, forcing reconnect", elapsed
-            )
+            self.warning("No data received for %.0fs, forcing reconnect", elapsed)
             if self._unsub_stale_check:
                 self._unsub_stale_check()
                 self._unsub_stale_check = None

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -47,6 +47,8 @@ _LOGGER = logging.getLogger(__name__)
 RECONNECT_INTERVAL = timedelta(seconds=5)
 # Subdevice: Offline events before disconnecting the device, around 5 minutes
 MIN_OFFLINE_EVENTS = 5 * 60 // HEARTBEAT_INTERVAL
+# How long to wait without receiving data before forcing a reconnect (zombie detection)
+STALE_DATA_TIMEOUT = 120
 
 
 class HassLocalTuyaData(NamedTuple):
@@ -89,6 +91,8 @@ class TuyaDevice(TuyaListener, ContextualLogger):
 
         # last_update_time: Sleep timer, a device that reports the status every x seconds then goes into sleep.
         self._last_update_time = time.monotonic() - 5
+        self._last_data_time: float = 0
+        self._unsub_stale_check: CALLBACK_TYPE | None = None
         self._pending_status: dict[str, dict[str, Any]] = {}
 
         self.is_closing = False
@@ -321,6 +325,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                 asyncio.create_task(self._connect_subdevices())
 
             self._interface.keep_alive(len(self.sub_devices) > 0)
+            self._start_stale_data_check()
 
         # If not connected try to handle the errors.
         if not self.connected and not self.is_closing:
@@ -374,6 +379,10 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         if self._unsub_refresh:
             self._unsub_refresh()
             self._unsub_refresh = None
+
+        if self._unsub_stale_check:
+            self._unsub_stale_check()
+            self._unsub_stale_check = None
 
         await self.abort_connect()
 
@@ -552,6 +561,34 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             k: v for k, v in self.sub_devices.items() if not v.is_closing
         }
 
+    def _start_stale_data_check(self):
+        """Start periodic check for zombie connections (connected but no data)."""
+        if self._unsub_stale_check:
+            self._unsub_stale_check()
+        if self.is_sleep or self.is_subdevice:
+            return
+        self._last_data_time = time.monotonic()
+        self._unsub_stale_check = async_track_time_interval(
+            self.hass,
+            self._check_stale_data,
+            timedelta(seconds=STALE_DATA_TIMEOUT),
+        )
+        self.debug("Started stale data watchdog (%ss)", STALE_DATA_TIMEOUT)
+
+    async def _check_stale_data(self, _now):
+        """Force reconnect if connected but no data received within timeout."""
+        if not self.connected or self.is_closing:
+            return
+        elapsed = time.monotonic() - self._last_data_time
+        if elapsed >= STALE_DATA_TIMEOUT:
+            self.warning(
+                "No data received for %.0fs, forcing reconnect", elapsed
+            )
+            if self._unsub_stale_check:
+                self._unsub_stale_check()
+                self._unsub_stale_check = None
+            self.disconnected("Stale data timeout")
+
     def _dispatch_status(self):
         signal = f"localtuya_{self._device_config.id}"
         dispatcher_send(self.hass, signal, self._status)
@@ -604,6 +641,7 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             return
 
         self._last_update_time = time.monotonic()
+        self._last_data_time = time.monotonic()
         self._handle_event(self._status, status)
         self._status.update(status)
         self._dispatch_status()
@@ -618,6 +656,10 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         if self._unsub_refresh:
             self._unsub_refresh()
             self._unsub_refresh = None
+
+        if self._unsub_stale_check:
+            self._unsub_stale_check()
+            self._unsub_stale_check = None
 
         for subdevice in self.sub_devices.values():
             subdevice.disconnected("Gateway disconnected")

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -47,8 +47,9 @@ _LOGGER = logging.getLogger(__name__)
 RECONNECT_INTERVAL = timedelta(seconds=5)
 # Subdevice: Offline events before disconnecting the device, around 5 minutes
 MIN_OFFLINE_EVENTS = 5 * 60 // HEARTBEAT_INTERVAL
-# How long to wait without receiving data before forcing a reconnect (zombie detection)
-STALE_DATA_TIMEOUT = 120
+# How long to wait without receiving data before probing the device (zombie detection).
+# 15 minutes is safe for devices like switches that only push on state change.
+STALE_DATA_TIMEOUT = 900
 
 
 class HassLocalTuyaData(NamedTuple):
@@ -562,7 +563,11 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         }
 
     def _start_stale_data_check(self):
-        """Start periodic check for zombie connections (connected but no data)."""
+        """Start periodic check for zombie connections.
+
+        When no data is received within STALE_DATA_TIMEOUT, probes the device
+        with update_dps. Only forces a reconnect if the probe gets no response.
+        """
         if self._unsub_stale_check:
             self._unsub_stale_check()
         if self.is_sleep or self.is_subdevice:
@@ -576,12 +581,37 @@ class TuyaDevice(TuyaListener, ContextualLogger):
         self.debug("Started stale data watchdog (%ss)", STALE_DATA_TIMEOUT)
 
     async def _check_stale_data(self, _now):
-        """Force reconnect if connected but no data received within timeout."""
+        """Probe device if no data received within timeout, reconnect if probe fails."""
         if not self.connected or self.is_closing:
             return
         elapsed = time.monotonic() - self._last_data_time
-        if elapsed >= STALE_DATA_TIMEOUT:
-            self.warning("No data received for %.0fs, forcing reconnect", elapsed)
+        if elapsed < STALE_DATA_TIMEOUT:
+            return
+
+        self.debug("No data received for %.0fs, probing device", elapsed)
+        before_probe = self._last_data_time
+        try:
+            await self._interface.update_dps(cid=self._node_id)
+            # Give the device a moment to respond with pushed data
+            await asyncio.sleep(5)
+        except (TimeoutError, Exception) as e:
+            self.warning("Stale data probe failed (%s), forcing reconnect", e)
+            if self._unsub_stale_check:
+                self._unsub_stale_check()
+                self._unsub_stale_check = None
+            self.disconnected("Stale data timeout")
+            return
+
+        if not self.connected or self.is_closing:
+            return
+
+        if self._last_data_time > before_probe:
+            self.debug("Device responded to probe, connection is healthy")
+        else:
+            self.warning(
+                "No data after probe (no update for %.0fs), forcing reconnect",
+                time.monotonic() - self._last_data_time,
+            )
             if self._unsub_stale_check:
                 self._unsub_stale_check()
                 self._unsub_stale_check = None

--- a/custom_components/localtuya/translations/ar.json
+++ b/custom_components/localtuya/translations/ar.json
@@ -135,7 +135,7 @@
       },
       "choose_template": {
         "title": "استيراد ملف القالب",
-        "description": "توجد ملفات القالب في المجلد `templates` ([لمعلومات أكثر](https://github.com/xZetsubou/hass-localtuya/discussions/13)).",
+        "description": "توجد ملفات القالب في المجلد `templates` ([لمعلومات أكثر]({templates_url})).",
         "data": {
           "templates": "اختيار القالب"
         }

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -139,7 +139,7 @@
             },
             "choose_template":{
                 "title": "Import template file",
-                "description": "Template files are located in the `templates` directory ([More Info](https://github.com/xZetsubou/hass-localtuya/discussions/13)).",
+                "description": "Template files are located in the `templates` directory ([More Info]({templates_url})).",
                 "data": {
                     "templates": "Choose template"
                 }

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -253,18 +253,18 @@
                     "swing_horizontal_modes": "(Optional) Available horizontal swing options"
                 },
                 "data_description": {
-                    "hvac_mode_set":"Each line represents [ hvac_mode: device_value ] [Supported HVAC Modes](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes)",
-                    "hvac_action_set":"Each line represents [ hvac_action: device_value ] [Supported HVAC Actions](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action)",
+                    "hvac_mode_set":"Each line represents [ hvac_mode: device_value ] [Supported HVAC Modes]({hvac_modes_url})",
+                    "hvac_action_set":"Each line represents [ hvac_action: device_value ] [Supported HVAC Actions]({hvac_actions_url})",
                     "preset_set":"Each line represents [ device_value: friendly name ]",
                     "scene_values":"Each line represents [ device_value: friendly name ]",
                     "select_options":"Each line represents [ device_value: friendly name ]",
                     "swing_modes":"Each line represents [ device_value: friendly name ]",
                     "swing_horizontal_modes":"Each line represents [ device_value: friendly name ]",
-                    "alarm_supported_states":"Each line represents [ supported state: device value ] [Supported States](https://developers.home-assistant.io/docs/core/entity/alarm-control-panel/#states)",
+                    "alarm_supported_states":"Each line represents [ supported state: device value ] [Supported States]({alarm_states_url})",
                     "humidifier_available_modes":"Each line represents [ device_value: friendly name ]",
                     "fan_speed_list":"Each line represents [ device_value: friendly name ]",
-                    "device_class": "Find out more about [Device Classes](https://www.home-assistant.io/integrations/homeassistant/#device-class)",
-                    "state_class": "Find out more about [State Classes](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes)"
+                    "device_class": "Find out more about [Device Classes]({device_class_url})",
+                    "state_class": "Find out more about [State Classes]({state_class_url})"
                 }
             }
         }

--- a/custom_components/localtuya/translations/it.json
+++ b/custom_components/localtuya/translations/it.json
@@ -238,16 +238,16 @@
                     "key_study_dp":"(Optional) Key Study DP (usually 7)"
                 },
                 "data_description": {
-                    "hvac_mode_set":"Each line represents [ hvac_mode: device_value ] [Supported HVAC Modes](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes)",
-                    "hvac_action_set":"Each line represents [ hvac_action: device_value ] [Supported HVAC Actions](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action)",
+                    "hvac_mode_set":"Each line represents [ hvac_mode: device_value ] [Supported HVAC Modes]({hvac_modes_url})",
+                    "hvac_action_set":"Each line represents [ hvac_action: device_value ] [Supported HVAC Actions]({hvac_actions_url})",
                     "preset_set":"Each line represents [ device_value: friendly name ]",
                     "scene_values":"Each line represents [ device_value: friendly name ]",
                     "select_options":"Each line represents [ device_value: friendly name ]",
-                    "alarm_supported_states":"Each line represents [ supported state: device value ] [Supported States](https://developers.home-assistant.io/docs/core/entity/alarm-control-panel/#states)",
+                    "alarm_supported_states":"Each line represents [ supported state: device value ] [Supported States]({alarm_states_url})",
                     "humidifier_available_modes":"Each line represents [ device_value: friendly name ]",
                     "fan_speed_list":"Each line represents [ device_value: friendly name ]",
-                    "device_class": "Find out more about [Device Classes](https://www.home-assistant.io/integrations/homeassistant/#device-class)",
-                    "state_class": "Find out more about [State Classes](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes)"
+                    "device_class": "Find out more about [Device Classes]({device_class_url})",
+                    "state_class": "Find out more about [State Classes]({state_class_url})"
                 }
             }
         }

--- a/custom_components/localtuya/translations/it.json
+++ b/custom_components/localtuya/translations/it.json
@@ -134,7 +134,7 @@
             },
             "choose_template": {
                 "title": "Importa file modello",
-                "description": "I file modello si trovano nella directory `templates` ([Maggiori informazioni](https://github.com/xZetsubou/hass-localtuya/discussions/13)).",
+                "description": "I file modello si trovano nella directory `templates` ([Maggiori informazioni]({templates_url})).",
                 "data": {
                     "templates": "Scegli modello"
                 }

--- a/custom_components/localtuya/translations/pl.json
+++ b/custom_components/localtuya/translations/pl.json
@@ -243,16 +243,16 @@
                     "key_study_dp":"(Optional) Key Study DP (usually 7)"
                 },
                 "data_description": {
-                    "hvac_mode_set":"Każda linia reprezentuje [ hvac_mode: device_value ] [Obsługiwane tryby HVAC](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes)",
-                    "hvac_action_set":"Każda linia reprezentuje [ hvac_action: device_value ] [Obsługiwane działania HVAC](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action)",
+                    "hvac_mode_set":"Każda linia reprezentuje [ hvac_mode: device_value ] [Obsługiwane tryby HVAC]({hvac_modes_url})",
+                    "hvac_action_set":"Każda linia reprezentuje [ hvac_action: device_value ] [Obsługiwane działania HVAC]({hvac_actions_url})",
                     "preset_set":"Każda linia reprezentuje [ device_value: friendly name ]",
                     "scene_values":"Każda linia reprezentuje [ device_value: friendly name ]",
                     "select_options":"Każda linia reprezentuje [ device_value: friendly name ]",
-                    "alarm_supported_states":"Each line represents [ supported state: device value ] [Supported States](https://developers.home-assistant.io/docs/core/entity/alarm-control-panel/#states)",
+                    "alarm_supported_states":"Each line represents [ supported state: device value ] [Supported States]({alarm_states_url})",
                     "humidifier_available_modes":"Każda linia reprezentuje [ device_value: friendly name ]",
                     "fan_speed_list":"Każda linia reprezentuje [ device_value: friendly name ]",
-                    "device_class": "Dowiedz się więcej o [Klasach urządzeń](https://www.home-assistant.io/integrations/homeassistant/#device-class)",
-                    "state_class": "Dowiedz się więcej o [Klasach stanów](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes)"
+                    "device_class": "Dowiedz się więcej o [Klasach urządzeń]({device_class_url})",
+                    "state_class": "Dowiedz się więcej o [Klasach stanów]({state_class_url})"
                 }
             }
         }

--- a/custom_components/localtuya/translations/pl.json
+++ b/custom_components/localtuya/translations/pl.json
@@ -139,7 +139,7 @@
             },
             "choose_template":{
                 "title": "Importuj plik szablonu",
-                "description": "Pliki szablonów znajdują się w katalogu `templates` ([Więcej informacji](https://github.com/xZetsubou/hass-localtuya/discussions/13)).",
+                "description": "Pliki szablonów znajdują się w katalogu `templates` ([Więcej informacji]({templates_url})).",
                 "data": {
                     "templates": "Wybierz szablon"
                 }

--- a/custom_components/localtuya/translations/pt-BR.json
+++ b/custom_components/localtuya/translations/pt-BR.json
@@ -238,16 +238,16 @@
                     "key_study_dp":"(Optional) Key Study DP (usually 7)"
                 },
                 "data_description": {
-                    "hvac_mode_set":"Each line represents [ hvac_mode: device_value ] [Supported HVAC Modes](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes)",
-                    "hvac_action_set":"Each line represents [ hvac_action: device_value ] [Supported HVAC Actions](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action)",
+                    "hvac_mode_set":"Each line represents [ hvac_mode: device_value ] [Supported HVAC Modes]({hvac_modes_url})",
+                    "hvac_action_set":"Each line represents [ hvac_action: device_value ] [Supported HVAC Actions]({hvac_actions_url})",
                     "preset_set":"Each line represents [ device_value: friendly name ]",
                     "scene_values":"Each line represents [ device_value: friendly name ]",
                     "select_options":"Each line represents [ device_value: friendly name ]",
-                    "alarm_supported_states":"Each line represents [ supported state: device value ] [Supported States](https://developers.home-assistant.io/docs/core/entity/alarm-control-panel/#states)",
+                    "alarm_supported_states":"Each line represents [ supported state: device value ] [Supported States]({alarm_states_url})",
                     "humidifier_available_modes":"Each line represents [ device_value: friendly name ]",
                     "fan_speed_list":"Each line represents [ device_value: friendly name ]",
-                    "device_class": "Find out more about [Device Classes](https://www.home-assistant.io/integrations/homeassistant/#device-class)",
-                    "state_class": "Find out more about [State Classes](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes)"
+                    "device_class": "Find out more about [Device Classes]({device_class_url})",
+                    "state_class": "Find out more about [State Classes]({state_class_url})"
                 }
             }
         }

--- a/custom_components/localtuya/translations/pt-BR.json
+++ b/custom_components/localtuya/translations/pt-BR.json
@@ -134,7 +134,7 @@
             },
             "choose_template":{
                 "title": "Importar arquivo de modelo",
-                "description": "Os arquivos de modelo estão localizados no diretório 'templates' ([Mais Informações](https://github.com/xZetsubou/hass-localtuya/discussions/13)).",
+                "description": "Os arquivos de modelo estão localizados no diretório 'templates' ([Mais Informações]({templates_url})).",
                 "data": {
                     "templates": "Escolher modelo"
                 }

--- a/custom_components/localtuya/translations/tr.json
+++ b/custom_components/localtuya/translations/tr.json
@@ -248,16 +248,16 @@
           "color_mode_set": "Desteklenen modlar seti (emin değilseniz varsayılanı bırakın)"
         },
         "data_description": {
-          "hvac_mode_set": "Her satır [ hvac_modu: cihaz_değeri ] temsil eder [Desteklenen HVAC Modları](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes)",
-          "hvac_action_set": "Her satır [ hvac_eylemi: cihaz_değeri ] temsil eder [Desteklenen HVAC Eylemleri](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action)",
+          "hvac_mode_set": "Her satır [ hvac_modu: cihaz_değeri ] temsil eder [Desteklenen HVAC Modları]({hvac_modes_url})",
+          "hvac_action_set": "Her satır [ hvac_eylemi: cihaz_değeri ] temsil eder [Desteklenen HVAC Eylemleri]({hvac_actions_url})",
           "preset_set": "Her satır [ cihaz_değeri: dostane ad ] temsil eder",
           "scene_values": "Her satır [ cihaz_değeri: dostane ad ] temsil eder",
           "select_options": "Her satır [ cihaz_değeri: dostane ad ] temsil eder",
-          "alarm_supported_states": "Her satır [ desteklenen durum: cihaz değeri ] temsil eder [Desteklenen Durumlar](https://developers.home-assistant.io/docs/core/entity/alarm-control-panel/#states)",
+          "alarm_supported_states": "Her satır [ desteklenen durum: cihaz değeri ] temsil eder [Desteklenen Durumlar]({alarm_states_url})",
           "humidifier_available_modes": "Her satır [ cihaz_değeri: dostane ad ] temsil eder",
           "fan_speed_list": "Her satır [ cihaz_değeri: dostane ad ] temsil eder",
-          "device_class": "[Cihaz Sınıfları](https://www.home-assistant.io/integrations/homeassistant/#device-class) hakkında daha fazla bilgi edinin",
-          "state_class": "[Durum Sınıfları](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes) hakkında daha fazla bilgi edinin"
+          "device_class": "[Cihaz Sınıfları]({device_class_url}) hakkında daha fazla bilgi edinin",
+          "state_class": "[Durum Sınıfları]({state_class_url}) hakkında daha fazla bilgi edinin"
         }
       }
     }

--- a/custom_components/localtuya/translations/tr.json
+++ b/custom_components/localtuya/translations/tr.json
@@ -139,7 +139,7 @@
       },
       "choose_template": {
         "title": "Şablon dosyasını içe aktar",
-        "description": "Şablon dosyaları `templates` dizininde bulunur ([Daha Fazla Bilgi](https://github.com/xZetsubou/hass-localtuya/discussions/13)).",
+        "description": "Şablon dosyaları `templates` dizininde bulunur ([Daha Fazla Bilgi]({templates_url})).",
         "data": {
           "templates": "Şablonu seçin"
         }

--- a/custom_components/localtuya/translations/vi.json
+++ b/custom_components/localtuya/translations/vi.json
@@ -140,7 +140,7 @@
             },
             "choose_template":{
                 "title": "Nhập file template",
-                "description": "File template nằm trong thư mục `templates` ([Xem thêm](https://github.com/xZetsubou/hass-localtuya/discussions/13)).",
+                "description": "File template nằm trong thư mục `templates` ([Xem thêm]({templates_url})).",
                 "data": {
                     "templates": "Chọn template"
                 }

--- a/custom_components/localtuya/translations/vi.json
+++ b/custom_components/localtuya/translations/vi.json
@@ -254,18 +254,18 @@
                     "swing_horizontal_modes": "(Tùy chọn) Các chế độ quay ngang"
                 },
                 "data_description": {
-                    "hvac_mode_set":"Mỗi dòng là [ hvac_mode: device_value ] [Các chế độ HVAC hỗ trợ](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes)",
-                    "hvac_action_set":"Mỗi dòng là [ hvac_action: device_value ] [Các trạng thái HVAC hỗ trợ](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action)",
+                    "hvac_mode_set":"Mỗi dòng là [ hvac_mode: device_value ] [Các chế độ HVAC hỗ trợ]({hvac_modes_url})",
+                    "hvac_action_set":"Mỗi dòng là [ hvac_action: device_value ] [Các trạng thái HVAC hỗ trợ]({hvac_actions_url})",
                     "preset_set":"Mỗi dòng là [ device_value: tên thân thiện ]",
                     "scene_values":"Mỗi dòng là [ device_value: tên thân thiện ]",
                     "select_options":"Mỗi dòng là [ device_value: tên thân thiện ]",
                     "swing_modes":"Mỗi dòng là [ device_value: tên thân thiện ]",
                     "swing_horizontal_modes":"Mỗi dòng là [ device_value: tên thân thiện ]",
-                    "alarm_supported_states":"Mỗi dòng là [ trạng thái hỗ trợ: device value ] [Các trạng thái hỗ trợ](https://developers.home-assistant.io/docs/core/entity/alarm-control-panel/#states)",
+                    "alarm_supported_states":"Mỗi dòng là [ trạng thái hỗ trợ: device value ] [Các trạng thái hỗ trợ]({alarm_states_url})",
                     "humidifier_available_modes":"Mỗi dòng là [ device_value: tên thân thiện ]",
                     "fan_speed_list":"Mỗi dòng là [ device_value: tên thân thiện ]",
-                    "device_class": "Tìm hiểu thêm về [Device Classes](https://www.home-assistant.io/integrations/homeassistant/#device-class)",
-                    "state_class": "Tìm hiểu thêm về [State Classes](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes)"
+                    "device_class": "Tìm hiểu thêm về [Device Classes]({device_class_url})",
+                    "state_class": "Tìm hiểu thêm về [State Classes]({state_class_url})"
                 }
             }
         }

--- a/custom_components/localtuya/translations/zh-Hans.json
+++ b/custom_components/localtuya/translations/zh-Hans.json
@@ -139,7 +139,7 @@
             },
             "choose_template":{
                 "title": "导入模板文件",
-                "description": "模板文件位于`templates`目录下（[更多信息](https://github.com/xZetsubou/hass-localtuya/discussions/13)）。",
+                "description": "模板文件位于`templates`目录下（[更多信息]({templates_url})）。",
                 "data": {
                     "templates": "选择模板"
                 }

--- a/custom_components/localtuya/translations/zh-Hans.json
+++ b/custom_components/localtuya/translations/zh-Hans.json
@@ -253,18 +253,18 @@
                     "swing_horizontal_modes": "（非必填）水平摆风选项（用英文逗号分隔）"
                 },
                 "data_description": {
-                    "hvac_mode_set": "每一行格式为 [ HVAC模式: 设备值 ] [HVAC模式参考](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes)",
-                    "hvac_action_set": "每一行格式为 [ HVAC动作: 设备值 ] [HVAC动作参考](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action)",
+                    "hvac_mode_set": "每一行格式为 [ HVAC模式: 设备值 ] [HVAC模式参考]({hvac_modes_url})",
+                    "hvac_action_set": "每一行格式为 [ HVAC动作: 设备值 ] [HVAC动作参考]({hvac_actions_url})",
                     "preset_set": "每一行格式为 [ 设备值: 显示名称 ]",
                     "scene_values": "每一行格式为 [ 设备值: 显示名称 ]",
                     "select_options": "每一行格式为 [ 设备值: 显示名称 ]",
                     "swing_modes": "每一行格式为 [ 设备值: 显示名称 ]",
                     "swing_horizontal_modes": "每一行格式为 [ 设备值: 显示名称 ]",
-                    "alarm_supported_states": "每一行格式为 [ 支持的状态: 设备值 ] [参考状态](https://developers.home-assistant.io/docs/core/entity/alarm-control-panel/#states)",
+                    "alarm_supported_states": "每一行格式为 [ 支持的状态: 设备值 ] [参考状态]({alarm_states_url})",
                     "humidifier_available_modes": "每一行格式为 [ 设备值: 显示名称 ]",
                     "fan_speed_list": "每一行格式为 [ 设备值: 显示名称 ]",
-                    "device_class": "查看更多 [设备类型](https://www.home-assistant.io/integrations/homeassistant/#device-class)",
-                    "state_class": "查看更多 [状态分类](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes)"
+                    "device_class": "查看更多 [设备类型]({device_class_url})",
+                    "state_class": "查看更多 [状态分类]({state_class_url})"
                 }
             }
         }


### PR DESCRIPTION
## Summary

After a discovery-triggered reload or reconnect, a device can enter a **zombie state** where the TCP connection is established and heartbeats succeed, but the device **never pushes any DPS status updates**. Entities remain stuck on `unknown` or stale values indefinitely — sometimes for 9+ hours — until a manual reload is performed.

This PR adds a **stale data watchdog** that detects zombie connections and automatically forces a reconnect.

## Problem

### Symptoms
- Device connects successfully (`Success: connected to: <IP>` in logs)
- Heartbeat keeps the TCP connection alive (no disconnect detected)
- But **no DPS data is ever pushed** by the device
- Sensors stay `unknown` or freeze on last cached value
- The Tuya Smart Life app shows the device is **online the entire time** — the issue is purely on the LocalTuya side
- Only a manual integration reload (sometimes multiple attempts) recovers the device

### Root Cause

The zombie state occurs after LocalTuya performs a full integration reload. The reload can be triggered by:

1. **Discovery** (`_device_discovered` in `__init__.py`) detecting a broadcast and calling `async_update_entry`, which fires `update_listener` → `async_reload`
2. **Manual reload** via the service call

After the reload cycle (`async_unload_entry` → `async_setup_entry`):
- New `TuyaDevice` objects are created
- TCP connections are established successfully
- Initial `status()` query may return cached/stale data
- `keep_alive()` heartbeat loop starts and succeeds
- **But the device stops pushing unsolicited status updates through the connection**

The Tuya local protocol (v3.4) allows only one local TCP session at a time. During the rapid disconnect/reconnect cycle of a reload, the device's session state can become inconsistent — it accepts the new TCP connection but doesn't register it for push notifications.

### Debug Logs Showing the Problem

**Discovery triggers a full reload (all devices disconnect simultaneously):**
```
2026-02-25 04:27:23.345 INFO  [localtuya] Unload completed
2026-02-25 04:27:23.363 DEBUG [pytuya] [Breaker] Connection lost: None
2026-02-25 04:27:23.377 INFO  [localtuya] Cloud API account not configured.
2026-02-25 04:27:23.491 INFO  [localtuya] localtuya: Setup completed
2026-02-25 04:27:23.666 DEBUG [coordinator] [Breaker] Success: connected to: 192.168.0.2
```

**After "successful" reconnect — connection keeps dropping and reconnecting but no data flows:**
```
2026-02-25 09:09:36.736 DEBUG [coordinator] [Breaker] Success: connected to: 192.168.0.2
2026-02-25 09:09:45.268 DEBUG [pytuya] [Breaker] Connection lost: None
2026-02-25 09:09:45.560 DEBUG [coordinator] [Breaker] Success: connected to: 192.168.0.2
2026-02-25 09:13:12.772 DEBUG [pytuya] [Breaker] Connection lost: None
2026-02-25 09:13:13.071 DEBUG [coordinator] [Breaker] Success: connected to: 192.168.0.2
```

**State history showing a 9.5-hour data gap (HA history API):**
```
Phase A Voltage:
  2026-02-24 10:57:31 UTC: 214.0V  ← last good data
  2026-02-24 20:31:03 UTC: 213.0V  ← data resumes 9.5 hours later

Total Energy:
  2026-02-24 10:56:52 UTC: 31.6 kWh
  2026-02-24 20:23:02 UTC: 37.1 kWh  ← device was counting energy the whole time
```

The energy jump from 31.6 → 37.1 kWh confirms the device was **powered and working** — it just wasn't sending data to LocalTuya.

## Solution

### 1. Stale Data Watchdog (`coordinator.py`)

Added a periodic check that runs every `STALE_DATA_TIMEOUT` (120 seconds) after a successful connection. It tracks the last time actual DPS data was received from the device via `status_updated()`. If no data arrives within the timeout:

- Logs a warning: `"No data received for Xs, forcing reconnect"`
- Calls `disconnected("Stale data timeout")` which triggers the existing reconnect loop
- The reconnect loop re-establishes the TCP connection, re-negotiates the session key, and requests fresh status

The watchdog is:
- **Only active for non-sleep, non-subdevice devices** (sleep devices have their own timing; subdevices share the gateway connection)
- **Properly cleaned up** on `close()` and `disconnected()` to prevent leaks
- **Reset on each successful connection** to avoid false positives during normal reconnects

### 2. Discovery Reload Visibility (`__init__.py`)

Changed the discovery-triggered config update log from `debug` to `warning` level. Previously, when discovery detected a device broadcast and triggered `async_update_entry` (which causes a full integration reload via `update_listener`), the log was at debug level and invisible in normal operation. This made it very difficult to diagnose why devices suddenly disconnected and reconnected.

## Changes

### `coordinator.py`
- Added `STALE_DATA_TIMEOUT = 120` constant
- Added `_last_data_time` and `_unsub_stale_check` instance variables to `TuyaDevice.__init__`
- Added `_start_stale_data_check()` — starts the periodic timer after successful connection
- Added `_check_stale_data()` — the periodic callback that detects zombie state
- Updated `status_updated()` to reset `_last_data_time` on each data receipt
- Updated `close()` and `disconnected()` to clean up the stale check timer
- Called `_start_stale_data_check()` after `keep_alive()` in `_make_connection()`

### `__init__.py`
- Changed `_LOGGER.debug` → `_LOGGER.warning` in `_device_discovered()` when a config update triggers a reload

## Testing

Tested on a real Tuya Smart Breaker (3-phase energy monitor, protocol v3.4, local-only / no cloud API) that was experiencing daily zombie connections lasting 9+ hours. After applying this fix:

- The watchdog correctly detects the zombie state within 120 seconds
- The forced reconnect successfully recovers data flow
- No false positives observed during normal operation (the device pushes data every few seconds)
- The warning log clearly shows when discovery triggers a reload

## Environment
- **LocalTuya version:** latest master
- **Home Assistant:** OS 17.1
- **Device:** Tuya Smart Breaker (3-phase energy monitor), protocol 3.4
- **Setup:** No cloud API, local only