### PR TITLE
fix(vacuum): fault_dp non-zero value incorrectly overrides vacuum status with ERROR

### DIFF
--- a/custom_components/localtuya/core/ha_entities/vacuums.py
+++ b/custom_components/localtuya/core/ha_entities/vacuums.py
@@ -79,7 +79,6 @@ VACUUMS: dict[str, tuple[LocalTuyaEntity, ...]] = {
             ),
             clean_area_dp=DPCode.CLEAN_AREA,
             clean_record_dp=DPCode.CLEAN_RECORD,
-            fault_dp=DPCode.FAULT,
             custom_configs=localtuya_vaccuums(
                 modes=DEFAULT_MODES,
                 returning_status_value=DEFAULT_RETURNING_STATUS,

--- a/custom_components/localtuya/vacuum.py
+++ b/custom_components/localtuya/vacuum.py
@@ -249,8 +249,6 @@ class LocalTuyaVacuum(LocalTuyaEntity, StateVacuumEntity):
 
         if self.has_config(CONF_FAULT_DP):
             self._attrs[FAULT] = self.dp_value(CONF_FAULT_DP)
-            if self._attrs[FAULT] != 0:
-                self._state = VacuumActivity.ERROR
 
 
 async_setup_entry = partial(async_setup_entry, DOMAIN, LocalTuyaVacuum, flow_schema)


### PR DESCRIPTION
Fixes #789

## Summary

Removes the `ERROR` state override in `vacuum.py` that fires whenever `fault_dp != 0`, and removes `fault_dp` from the `sd` category auto-configure in `vacuums.py`.

## Problem

The `!= 0` check in `status_updated()` treats any non-zero fault bitfield value as an error state, unconditionally overriding the correctly resolved activity state from the status DPS. On the Lubluelu SL60D (and potentially other sd category vacuums), the fault DPS contains informational bits that are permanently non-zero during normal operation, causing the vacuum to always display "Error" even when docked and fully charged.

Additionally, the `sd` category in `vacuums.py` auto-configures `fault_dp` for all robot vacuums, meaning any user with cloud API setup and a non-zero informational fault bitfield will hit this bug automatically.

## Why this is safe for all vacuum users

Tuya's own sd category specification includes `in_trouble` as an explicit status DPS value for error conditions. The status DPS is the authoritative source of vacuum activity state - the fault DPS describes what the fault is, not that one exists.

After this change:
- The fault value is still stored as `self._attrs[FAULT]` (state attribute)
- The fault binary sensor entity is completely unaffected
- Vacuums whose status DPS reports error states directly are unaffected
- Vacuums with fault DPS always at 0 are unaffected (no behavioural change)
- Only vacuums with non-zero informational fault bitfields are fixed

## Files changed

- `custom_components/localtuya/vacuum.py` - removed `ERROR` state override, retaining the fault value as a state attribute
- `custom_components/localtuya/core/ha_entities/vacuums.py` - removed `fault_dp=DPCode.FAULT` from `sd` category auto-configure

## CI Notes

The change in `vacuum.py` is a pure two-line deletion with no new code added, so `black` formatting and `codespell` are unaffected. No new test coverage has been added - the change removes an unconditional override rather than introducing new logic.

## AI Disclosure

This pull request was developed with the assistance of the Claude AI agent.