### PR TITLE
fix(fan): respect fan_dps_type config for speed control

### DIFF
--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -145,12 +145,15 @@ class LocalTuyaFan(LocalTuyaEntity, FanEntity):
                     percentage_to_ordered_list_item(self._ordered_list, percentage),
                 )
             else:
+                value = int(
+                    math.ceil(
+                        percentage_to_ranged_value(self._speed_range, percentage)
+                    )
+                )
+                if self._config.get(CONF_FAN_DPS_TYPE, "int") == "str":
+                    value = str(value)
                 await self._device.set_dp(
-                    int(
-                        math.ceil(
-                            percentage_to_ranged_value(self._speed_range, percentage)
-                        )
-                    ),
+                    value,
                     self._config.get(CONF_FAN_SPEED_CONTROL),
                 )
                 _LOGGER.debug(


### PR DESCRIPTION
## Summary
- Some Tuya devices use **string-type DPS values** for fan speed (e.g., `"5"` instead of `5`)
- The `fan_dps_type` config option exists for this but was **not used** in the ranged-value code path of `async_set_percentage`
- This caused `Command 7 timed out waiting for sequence number` errors when setting fan speed, as the device silently rejected integer-typed values

## Root cause
In `fan.py`, the ordered-list path correctly sends speed as `str()`, but the ranged-value path always sent `int()`, ignoring `CONF_FAN_DPS_TYPE`.

## Fix
Check `CONF_FAN_DPS_TYPE` and convert the speed value to `str` when configured as `"str"`.

## Test plan
- [x] Tested on a ventilation system (product key `ddrpa4plk6fsvz9l`) with string-type DPS 102/103
- [x] Verified `fan.set_percentage` succeeds and device reports updated speed
- [x] Verified `fan.turn_on` / `fan.turn_off` still work (DP 101, boolean type)
- [x] Verified devices with `fan_dps_type: "int"` (default) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)