### PR TITLE
[codex] add event-driven low-power device support

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -75,6 +75,7 @@ from .const import (
     PLATFORMS,
     SUPPORTED_PROTOCOL_VERSIONS,
     CONF_DEVICE_SLEEP_TIME,
+    CONF_DEVICE_EVENT_DRIVEN,
 )
 from .discovery import discover
 
@@ -154,6 +155,7 @@ DEVICE_SCHEMA = vol.Schema(
         vol.Optional(CONF_MANUAL_DPS): cv.string,
         vol.Optional(CONF_RESET_DPIDS): str,
         vol.Optional(CONF_DEVICE_SLEEP_TIME): int,
+        vol.Required(CONF_DEVICE_EVENT_DRIVEN, default=False): bool,
         vol.Optional(CONF_NODE_ID, default=None): vol.Any(None, cv.string),
     }
 )
@@ -1055,6 +1057,7 @@ def options_schema(entities):
             vol.Optional(CONF_MANUAL_DPS): cv.string,
             vol.Optional(CONF_RESET_DPIDS): cv.string,
             vol.Optional(CONF_DEVICE_SLEEP_TIME): int,
+            vol.Required(CONF_DEVICE_EVENT_DRIVEN, default=False): bool,
             vol.Required(
                 CONF_ENTITIES, description={"suggested_value": entity_names}
             ): cv.multi_select(entity_names),
@@ -1234,7 +1237,10 @@ async def validate_input(entry_runtime: HassLocalTuyaData, data):
                 except:
                     continue
                 finally:
-                    if not auto_protocol and data.get(CONF_DEVICE_SLEEP_TIME, 0) > 0:
+                    if not auto_protocol and (
+                        data.get(CONF_DEVICE_SLEEP_TIME, 0) > 0
+                        or data.get(CONF_DEVICE_EVENT_DRIVEN, False)
+                    ):
                         logger.info("Low-power device configured — handshake skipped")
                         bypass_connection = True
                     if not error and not interface:

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -78,6 +78,7 @@ CONF_DEFAULT_VALUE = "dps_default_value"
 CONF_RESET_DPIDS = "reset_dpids"
 CONF_PASSIVE_ENTITY = "is_passive_entity"
 CONF_DEVICE_SLEEP_TIME = "device_sleep_time"
+CONF_DEVICE_EVENT_DRIVEN = "device_event_driven"
 
 # ALARM
 CONF_ALARM_SUPPORTED_STATES = "alarm_supported_states"
@@ -282,6 +283,9 @@ class DeviceConfig:
         self.entities: list = self.device_config[CONF_ENTITIES]
         self.protocol_version: str = self.device_config[CONF_PROTOCOL_VERSION]
         self.sleep_time: int = self.device_config.get(CONF_DEVICE_SLEEP_TIME, 0)
+        self.event_driven: bool = self.device_config.get(
+            CONF_DEVICE_EVENT_DRIVEN, False
+        )
         self.scan_interval: int = self.device_config.get(CONF_SCAN_INTERVAL, 0)
         self.enable_debug: bool = self.device_config.get(CONF_ENABLE_DEBUG, False)
         self.name: str = self.device_config.get(CONF_FRIENDLY_NAME)

--- a/custom_components/localtuya/coordinator.py
+++ b/custom_components/localtuya/coordinator.py
@@ -136,6 +136,10 @@ class TuyaDevice(TuyaListener, ContextualLogger):
     @property
     def is_sleep(self):
         """Return whether the device is sleep or not."""
+        if self._device_config.event_driven:
+            setattr(self, "low_power", True)
+            return True
+
         if (device_sleep := self._device_config.sleep_time) > 0:
             setattr(self, "low_power", True)
             last_update = time.monotonic() - self._last_update_time
@@ -298,7 +302,10 @@ class TuyaDevice(TuyaListener, ContextualLogger):
                     self.hass, signal, _new_entity_handler
                 )
 
-            if (scan_inv := int(self._device_config.scan_interval)) > 0:
+            if (
+                not self._device_config.event_driven
+                and (scan_inv := int(self._device_config.scan_interval)) > 0
+            ):
                 self._unsub_refresh = async_track_time_interval(
                     self.hass, self._async_refresh, timedelta(seconds=scan_inv)
                 )
@@ -320,7 +327,8 @@ class TuyaDevice(TuyaListener, ContextualLogger):
             if self.sub_devices:
                 asyncio.create_task(self._connect_subdevices())
 
-            self._interface.keep_alive(len(self.sub_devices) > 0)
+            if not self._device_config.event_driven:
+                self._interface.keep_alive(len(self.sub_devices) > 0)
 
         # If not connected try to handle the errors.
         if not self.connected and not self.is_closing:

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -109,6 +109,7 @@
                     "manual_dps_strings": "(Optional) Manual DPS's, if not detected automatically (separated by commas)",
                     "reset_dpids": "(Optional) DPIDs to send in RESET command, if device does not respond to status requests after turning on (separated by commas)",
                     "device_sleep_time": "(Optional) Device sleep time in seconds: If the device reports its state, then it goes into sleep",
+                    "device_event_driven": "(Optional) Event-driven low-power device: keep the last state and avoid heartbeat/refresh loops",
                     "export_config": "Save entity configuration as template"
                 }
             },

--- a/documentation/docs/faq/index.md
+++ b/documentation/docs/faq/index.md
@@ -6,6 +6,7 @@
     The device will report its status every x minutes. Most of the time, the device will go into sleep mode, and most likely it will disconnect from the network.
     Some Device has an option to control the reports period.
     In order to add this device, you need to specify the device sleep time in the [device configartion](../usage/configure_add_device.md). <br>
+    If the device only wakes up when an event happens, such as `motion detected` or `door opened/closed`, enable the `event-driven low-power device` option instead of relying on a fixed sleep time. <br>
     !!! tip ""
         If you add the device while it's sleeping and it's `disconnected` from the network, it won't connect <br>
         If you changed any value on the device while it is asleep, the new states will be applied when it wakes up. <br>
@@ -43,4 +44,3 @@
 <!-- ### Scenes Controllers
 !!! abstract ""
     If you want to control Home Assistant automations from scene control devices, such as `remotes or switches`, you should consider adding them and relying on [events](/ha_events/) -->
-

--- a/documentation/docs/usage/configure_add_device.md
+++ b/documentation/docs/usage/configure_add_device.md
@@ -65,6 +65,10 @@ Go to hub `Configure` (1) a menu will show up (2) Choose `Add new device`
         Only needed if the device has low-power mode and is disconnected from the network. [FAQ](../faq/index.md) <br>
         If the device is disconnected and exceeds this time, it will be considered offline
 
+    ??? info "(optional) Event-driven low-power device"
+        Enable this for devices that do not report on a predictable schedule and only wake up when an event occurs, such as motion or open/close sensors. <br>
+        LocalTuya will keep the last known state and skip heartbeat and refresh loops so the device can sleep normally.
+
 
     ??? info "(Optional) Node ID or CID"
         `Node ID` also known as `CID` only for sub devices that work through `Gateways` e.g. `ZigBee` and `BLE` Devices. 
@@ -184,4 +188,3 @@ There are two ways to create templates
         platform: binary_sensor
         state_on: '1'
     ```
-

--- a/tests/test_low_power.py
+++ b/tests/test_low_power.py
@@ -1,0 +1,92 @@
+"""Tests for low-power device handling."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from custom_components.localtuya import TuyaCloudApi, coordinator
+from custom_components.localtuya.const import DOMAIN
+
+from . import DEVICE_CONFIG, DEVICE_NAME, create_entry
+
+
+def build_device(*, event_driven: bool = False, scan_interval: int = 0):
+    """Build a TuyaDevice for low-power tests."""
+    config = {
+        DEVICE_NAME: {
+            **DEVICE_CONFIG,
+            "entities": [],
+            "device_event_driven": event_driven,
+            "scan_interval": scan_interval,
+        }
+    }
+
+    hass = HomeAssistant("")
+    entry = ConfigEntry(**create_entry(config))
+    tuya_api = TuyaCloudApi("EU", "test_client_id", "test_secret", "test_user_id")
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = coordinator.HassLocalTuyaData(tuya_api, {})
+
+    return coordinator.TuyaDevice(hass, entry, config[DEVICE_NAME])
+
+
+@pytest.mark.asyncio
+async def test_event_driven_device_is_treated_as_sleeping():
+    """Event-driven low-power devices should always behave as sleeping devices."""
+    device = build_device(event_driven=True)
+
+    assert device.is_sleep is True
+
+
+@pytest.mark.asyncio
+async def test_event_driven_device_skips_keep_alive_and_refresh():
+    """Event-driven devices should avoid active maintenance loops."""
+    device = build_device(event_driven=True, scan_interval=30)
+
+    interface = AsyncMock()
+    interface.is_connected = True
+    interface.status = AsyncMock(return_value={"1": "closed"})
+    interface.enable_debug = Mock()
+    interface.add_dps_to_request = Mock()
+    interface.keep_alive = Mock()
+
+    with (
+        patch(
+            "custom_components.localtuya.coordinator.pytuya_connect",
+            new=AsyncMock(return_value=interface),
+        ),
+        patch(
+            "custom_components.localtuya.coordinator.dispatcher_send"
+        ),
+        patch(
+            "custom_components.localtuya.coordinator.async_dispatcher_connect",
+            return_value=lambda: None,
+        ),
+        patch(
+            "custom_components.localtuya.coordinator.async_track_time_interval"
+        ) as track_interval,
+    ):
+        await device._make_connection()
+
+    track_interval.assert_not_called()
+    interface.keep_alive.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_event_driven_shutdown_keeps_last_state_available():
+    """Event-driven devices should not be forced unavailable after disconnect."""
+    device = build_device(event_driven=True)
+
+    with (
+        patch(
+            "custom_components.localtuya.coordinator.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+        patch("custom_components.localtuya.coordinator.dispatcher_send") as dispatcher,
+    ):
+        await device._shutdown_entities("sleeping")
+
+    dispatcher.assert_not_called()


### PR DESCRIPTION
## Summary
- add a dedicated `device_event_driven` option for low-power devices that only wake up on events
- skip heartbeat and refresh loops for event-driven devices while keeping the last known state available
- document the new option and cover the behavior with focused tests

## Why
Some battery-powered Wi-Fi sensors do not report on a fixed interval. They only wake when an event occurs, such as motion or an open/close change. Treating them like timed sleepers can lead to unnecessary keep-alives, refresh attempts, or unavailable state churn.

## Validation
- `uv run --python 3.12 --prerelease=allow --with-requirements requirements_test.txt pytest`
