### PR TITLE
feat: expose update_dps as a Home Assistant service

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -59,6 +59,14 @@ SERVICE_SET_DP_SCHEMA = vol.Schema(
     }
 )
 
+SERVICE_UPDATE_DPS = "update_dps"
+SERVICE_UPDATE_DPS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+        vol.Optional("dps"): list,
+    }
+)
+
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the LocalTuya integration component."""
@@ -97,6 +105,26 @@ async def async_setup(hass: HomeAssistant, config: dict):
             await device.set_dps(value)
         else:
             await device.set_dp(value, event.data[CONF_DP])
+
+    async def _handle_update_dps(event: ServiceCall):
+        """Handle update_dps service call - sends UPDATEDPS (0x12) command."""
+        dev_id = event.data[CONF_DEVICE_ID]
+        entry: ConfigEntry = async_config_entry_by_device_id(hass, dev_id)
+        if not entry or not entry.entry_id:
+            raise HomeAssistantError("unknown device id")
+
+        host = entry.data[CONF_DEVICES][dev_id].get(CONF_HOST)
+        if node_id := entry.data[CONF_DEVICES][dev_id].get(CONF_NODE_ID):
+            host = f"{host}_{node_id}"
+        device: TuyaDevice = hass.data[DOMAIN][entry.entry_id].devices[host]
+        if not device.connected:
+            raise HomeAssistantError("not connected to device")
+
+        dps = event.data.get("dps")
+        try:
+            await device._interface.update_dps(dps=dps, cid=device._node_id)
+        except TimeoutError:
+            pass
 
     def _device_discovered(device: dict):
         """Update address of device if it has changed."""
@@ -170,6 +198,13 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
     hass.services.async_register(
         DOMAIN, SERVICE_SET_DP, _handle_set_dp, schema=SERVICE_SET_DP_SCHEMA
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_UPDATE_DPS,
+        _handle_update_dps,
+        schema=SERVICE_UPDATE_DPS_SCHEMA,
     )
 
     discovery = TuyaDiscovery(_device_discovered)

--- a/custom_components/localtuya/services.yaml
+++ b/custom_components/localtuya/services.yaml
@@ -29,6 +29,25 @@ set_dp:
       selector:
         object:
 
+update_dps:
+  name: "Update DPs"
+  description: "Request the device to report current values for specified datapoints (sends UPDATEDPS 0x12 command)"
+  fields:
+    device_id:
+      name: "Device ID"
+      description: The Tuya device ID to request updated DP values from
+      required: true
+      example: 11100118278aab4de001
+      selector:
+        text:
+    dps:
+      name: "DPs"
+      description: "List of DP indexes to refresh. If omitted, all detected and whitelisted DPs will be refreshed."
+      required: false
+      example: "[18, 19, 20]"
+      selector:
+        object:
+
 remote_add_code:
   name: "Add Remote Code"
   description: Add the remote code to the device's remote storage.


### PR DESCRIPTION
## Summary

- Adds a new `localtuya.update_dps` service that sends the Tuya `UPDATEDPS` (`0x12`) protocol command to request fresh datapoint values from a device
- Accepts an optional `dps` parameter to specify which DP indexes to refresh (defaults to all detected and whitelisted DPs)
- Enables on-demand DPS refresh from automations and scripts without requiring a constant `scan_interval`

## Motivation

Currently, the only way to trigger the `UPDATEDPS` command is via the periodic `scan_interval` timer. This means users who want fresh energy monitoring data (current, power, voltage — typically DPs 18, 19, 20) must configure a fixed polling interval that runs continuously, even when the device is idle.

By exposing `update_dps` as a service, users can build smarter automations that only poll when needed — for example, refreshing energy DPs every few seconds only while a smart plug is actively in use, and stopping when it's off.

### Example automation
```yaml
automation:
  - alias: "Poll energy only when plug is on"
    trigger:
      - platform: time_pattern
        seconds: "/10"
    condition:
      - condition: state
        entity_id: switch.my_plug
        state: "on"
    action:
      - action: localtuya.update_dps
        data:
          device_id: "my_device_id"
          dps:
            - 18
            - 19
            - 20
```

## Changes

- `__init__.py`: Added `SERVICE_UPDATE_DPS` schema, `_handle_update_dps` handler, and service registration
- `services.yaml`: Added `update_dps` service definition with `device_id` and optional `dps` fields

## Test plan

- [x] Manually tested on a Tuya smart plug — calling the service updates `last_updated` on energy sensor entities
- [ ] Verify behavior with sub-devices (gateway + node_id)
- [ ] Verify behavior when `dps` parameter is omitted (should refresh all whitelisted DPs)
- [ ] Verify error handling when device is disconnected