### PR TITLE
Change liquid depth sensor unit conversion factor

### DIFF
--- a/custom_components/localtuya/core/ha_entities/sensors.py
+++ b/custom_components/localtuya/core/ha_entities/sensors.py
@@ -1862,7 +1862,7 @@ SENSORS: dict[str, tuple[LocalTuyaEntity, ...]] = {
             id=DPCode.LIQUID_DEPTH,
             name="Depth",
             icon="mdi:altimeter",
-            custom_configs=localtuya_sensor(UnitOfLength.METERS, 1),
+            custom_configs=localtuya_sensor(UnitOfLength.METERS, 0.01),
         ),
         LocalTuyaEntity(
             id=DPCode.LIQUID_LEVEL_PERCENT,


### PR DESCRIPTION
Fix #801: Apply the scale factor to the liquid depth sensor unit so it matches the reported value, as well as the maximum liquid depth value displayed in meters.