### PR TITLE
fix: v3.5 session key negotiation failures on reconnect

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -1227,6 +1227,10 @@ async def validate_input(entry_runtime: HassLocalTuyaData, data):
                         break
 
                 # If connection to host is failed raise wrong address.
+                except ConnectionAbortedError:
+                    # Protocol mismatch (e.g. v3.4 negotiation against v3.5 device);
+                    # keep trying other versions.
+                    continue
                 except (OSError, ValueError) as ex:
                     logger.error(f"Connection failed! {ex}")
                     error = ex

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -693,7 +693,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
     def clean_up_session(self):
         """Clean up session."""
         self.debug(f"Cleaning up session.")
-        self.real_local_key = self.local_key
+        self.local_key = self.real_local_key
 
         if self.heartbeater:
             self.heartbeater.cancel()
@@ -1026,7 +1026,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
     async def _negotiate_session_key(self):
         self.remote_nonce = b""
         self.local_key = self.real_local_key
+        self.dispatcher.local_key = self.real_local_key
 
+        rkey = None
         try:
             rkey = await self.exchange_quick(
                 MessagePayload(CMDType.SESS_KEY_NEG_START, self.local_nonce), 2


### PR DESCRIPTION
- Fix reversed assignment in clean_up_session(): was overwriting real_local_key with session key, causing next reconnect to encrypt SESS_KEY_NEG_START with stale session key instead of device key
- Reset dispatcher.local_key to real_local_key at start of _negotiate_session_key() so incoming SESS_KEY_NEG_RESP is decrypted with the correct key
- Initialize rkey=None before try block to avoid NameError if an exception is raised while device is still connected