### PR TITLE
Fix Music effect not switching work_mode to music (#810)

### DIFF
--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -551,7 +551,7 @@ class LocalTuyaLight(LocalTuyaEntity, LightEntity):
                     states[self._config.get(CONF_SCENE)] = scene
             elif effect in self._modes.as_list():
                 color_mode = effect
-            elif effect == self._modes.music:
+            elif effect == SCENE_MUSIC:
                 color_mode = self._modes.music
 
         if ATTR_BRIGHTNESS in kwargs and (


### PR DESCRIPTION
## Summary
Fixes #810 — selecting the **Music** effect never switched the device into music mode (`work_mode` DP stayed `colour`).

## Root cause
When `music_mode` is enabled, `SCENE_MUSIC` (`"Music"`) is appended to the effect list. But in `async_turn_on` the incoming effect was compared against `self._modes.music`, which is the **DP value** `MODE_MUSIC` (`"music"`):

```python
elif effect == self._modes.music:   # "Music" == "music"  -> always False
    color_mode = self._modes.music
```

Since `"Music" != "music"`, the branch never matched, `color_mode` stayed `None`, and no `work_mode` was written — the light remained in colour mode.

## Fix
Compare the incoming effect against the effect label `SCENE_MUSIC`:

```python
elif effect == SCENE_MUSIC:
    color_mode = self._modes.music
```

## Verification (real device)
Wi‑Fi RGB light, category `dj`, protocol 3.5, `work_mode` enum `white/colour/scene/music`, `music_mode` enabled.

| step | action | work_mode |
|------|--------|-----------|
| 1 | light on (normal) | `colour` |
| 2 | `light.turn_on` `effect: Music` (before fix) | `colour` ← never changed |
| 3 | `localtuya.set_dp` dp=21 `music` (control) | `music` |

Step 3 confirms the device/DP accept `music` fine — only the effect-handling path was affected. With this change, step 2 now writes `work_mode = music` as expected.
