### PR TITLE
fix(sensors): create phase sub-sensors thread-safely

### DIFF
--- a/custom_components/localtuya/sensor.py
+++ b/custom_components/localtuya/sensor.py
@@ -99,7 +99,9 @@ class LocalTuyaSensor(LocalTuyaEntity, SensorEntity):
 
         if self.is_base64(state):
             if not self._has_sub_entities:
-                self.hass.add_job(self.__create_sub_sensors())
+                self.hass.loop.call_soon_threadsafe(
+                    self.hass.async_create_task, self.__create_sub_sensors()
+                )
 
             if None not in (
                 sub_sensor := getattr(self, "_attr_sub_sensor", None),

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,71 @@
+"""Test for localtuya sensor platform."""
+
+from unittest.mock import MagicMock
+
+from . import *
+from custom_components.localtuya.sensor import LocalTuyaSensor, DOMAIN as PLATFORM_DOMAIN
+
+# Raw 3-phase breaker payload -> 214.0 V, 1.2 A, 0.177 kW
+PHASE_B64 = "CFwABLAAALE="
+PHASE_DECODED = {"voltage": 214.0, "current": 1.2, "power": 0.177}
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Phase A",
+                "icon": "",
+                "id": "6",
+                "platform": PLATFORM_DOMAIN,
+                "restore_on_reconnect": False,
+            }
+        ],
+    }
+}
+
+
+async def test_decode_base64():
+    """Raw base64 phase data is decoded into voltage/current/power."""
+    device = await init(CONFIG, PLATFORM_DOMAIN, LocalTuyaSensor)
+    sensor, *_ = get_entites(device)
+
+    assert type(sensor) is LocalTuyaSensor
+    assert sensor.is_base64(PHASE_B64)
+    assert not sensor.is_base64("500")
+    assert sensor.decode_base64(PHASE_B64) == PHASE_DECODED
+
+
+async def test_base64_status_creates_sub_sensors(monkeypatch):
+    """A base64 phase DP spawns decoded voltage/current/power sub-sensors."""
+    device = await init(CONFIG, PLATFORM_DOMAIN, LocalTuyaSensor)
+    sensor, *_ = get_entites(device)
+    sensor.entity_id = "sensor.phase_a"
+
+    created = []
+    sensor.componet_add_entities = lambda entities: created.extend(entities)
+    monkeypatch.setattr(
+        "custom_components.localtuya.sensor.er.async_get", lambda hass: MagicMock()
+    )
+
+    # Sub-sensor creation is scheduled on the event loop; run it synchronously.
+    def run_coro(coro, **kwargs):
+        try:
+            coro.send(None)
+        except StopIteration:
+            pass
+
+    sensor.hass.async_create_task = run_coro
+    sensor.hass.loop = MagicMock()
+    sensor.hass.loop.call_soon_threadsafe = lambda func, *args, **kwargs: func(*args)
+
+    device.status_updated({"6": PHASE_B64})
+
+    assert len(created) == 3
+    assert {e._attr_sub_sensor for e in created} == {"voltage", "current", "power"}
+
+    for sub in created:
+        sub._status = {"6": PHASE_B64}
+        sub.status_updated()
+    assert {e._attr_sub_sensor: e.native_value for e in created} == PHASE_DECODED


### PR DESCRIPTION
## What's wrong

For raw "phase" DPs (3-phase energy meters/breakers), the sensor is supposed to spawn `voltage` / `current` / `power` sub-sensors. Instead, on recent Home Assistant cores the sub-sensors are never created: the parent sensor just shows the raw base64 payload and stays visible, and no `*_voltage/_current/_power` entities appear.

## Why

`LocalTuyaSensor.status_updated()` is dispatched from an executor thread (not the event loop) and schedules the sub-sensor creation with:

```python
self.hass.add_job(self.__create_sub_sensors())
```

Passing a coroutine to `hass.add_job()` is deprecated and, on recent cores, it no longer schedules it — the coroutine is dropped with a "coroutine was never awaited" warning, so `__create_sub_sensors()` never runs and the sub-entities are never added. (Older cores still routed `add_job` through `async_create_task`, which is why this only shows up on newer HA.)

## Fix

Schedule the coroutine on the event loop in a thread-safe way:

```python
self.hass.loop.call_soon_threadsafe(
    self.hass.async_create_task, self.__create_sub_sensors()
)
```

`call_soon_threadsafe` is safe to call from the executor thread and hands the coroutine to `async_create_task` on the loop, so the voltage/current/power sub-sensors are created again. `async_create_task` alone is not enough here — it must run on the loop thread and would raise a thread-safety error.

## Tests

Adds `tests/test_sensor.py` (the sensor platform had no tests) covering the base64 phase decoding and the sub-sensor creation path.
