### PR TITLE
Fix stale cloud device list in add-device flow

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -322,6 +322,11 @@ class LocalTuyaOptionsFlowHandler(OptionsFlow):
         self.editing_device = False
         self.selected_device = None
         errors = {}
+        if not self.config_entry.data.get(CONF_NO_CLOUD, True):
+            res = await self.cloud_data.async_get_devices_list(force_update=True)
+            if res and res != "ok":
+                _LOGGER.warning("Failed to refresh Tuya cloud device list: %s", res)
+
         if user_input is not None:
             if user_input[SELECTED_DEVICE] != CUSTOM_DEVICE["Add Device Manually"]:
                 self.selected_device = user_input[SELECTED_DEVICE]
@@ -367,6 +372,12 @@ class LocalTuyaOptionsFlowHandler(OptionsFlow):
 
         allDevices = mergeDevicesList(
             self.discovered_devices, self.cloud_data.device_list
+        )
+        _LOGGER.debug(
+            "Merged device list: local/discovered=%s cloud=%s merged=%s",
+            len(self.discovered_devices),
+            len(self.cloud_data.device_list),
+            len(allDevices),
         )
 
         self.discovered_devices = allDevices
@@ -581,7 +592,10 @@ class LocalTuyaOptionsFlowHandler(OptionsFlow):
             defaults[CONF_FRIENDLY_NAME] = user_in.get(CONF_FRIENDLY_NAME, "")
             defaults[CONF_NODE_ID] = user_in.get(CONF_NODE_ID, "")
 
-            if defaults[CONF_DEVICE_ID] in [cloud_devs, self.selected_device]:
+            if (
+                defaults[CONF_DEVICE_ID] in cloud_devs
+                or defaults[CONF_DEVICE_ID] == self.selected_device
+            ):
                 dev_id = defaults[CONF_DEVICE_ID]
 
             if dev_id is not None and dev_id in self.discovered_devices:

--- a/custom_components/localtuya/core/cloud_api.py
+++ b/custom_components/localtuya/core/cloud_api.py
@@ -206,12 +206,10 @@ class TuyaCloudApi:
 
     async def async_get_devices_list(self, force_update=False) -> str | None:
         """Obtain the list of devices associated to a user. - force_update will ignore last update check."""
-        interval = (
-            DEVICES_UPDATE_INTERVAL_FORCED if force_update else DEVICES_UPDATE_INTERVAL
-        )
         if (
-            self.device_list
-            and int(time.time()) - (self._last_devices_update + interval) < 0
+            not force_update
+            and self.device_list
+            and int(time.time()) < self._last_devices_update + DEVICES_UPDATE_INTERVAL
         ):
             return self._logger.debug(f"Devices has been updated a minutes ago.")
 
@@ -225,7 +223,11 @@ class TuyaCloudApi:
         if not resp["success"]:
             return f"Error {resp['code']}: {resp['msg']}"
 
-        self.device_list.update({dev["id"]: dev for dev in resp["result"]})
+        devices = {dev["id"]: dev for dev in resp["result"]}
+        if force_update:
+            self.device_list = devices
+        else:
+            self.device_list.update(devices)
 
         self._last_devices_update = int(time.time())
         return "ok"

--- a/tests/test_cloud_api.py
+++ b/tests/test_cloud_api.py
@@ -1,0 +1,75 @@
+import time
+
+from custom_components.localtuya.core.cloud_api import TuyaCloudApi
+
+
+async def test_force_update_bypasses_cache_and_replaces_device_list():
+    """Force refresh should ignore the recent-update cache and replace stale devices."""
+    cloud_api = TuyaCloudApi("eu", "client_id", "secret", "user_id")
+    cloud_api.device_list = {"old_device": {"id": "old_device"}}
+    cloud_api._last_devices_update = int(time.time())
+    calls = []
+
+    async def mock_make_request(method, url, body=None, headers={}):
+        calls.append((method, url))
+        return {
+            "success": True,
+            "result": [
+                {"id": "fresh_device", "name": "Fresh Device"},
+            ],
+        }
+
+    cloud_api.async_make_request = mock_make_request
+
+    result = await cloud_api.async_get_devices_list(force_update=True)
+
+    assert result == "ok"
+    assert calls == [("GET", "/v1.0/users/user_id/devices")]
+    assert cloud_api.device_list == {
+        "fresh_device": {"id": "fresh_device", "name": "Fresh Device"}
+    }
+
+
+async def test_cached_regular_refresh_does_not_request_cloud():
+    """Regular refresh keeps using the cache while it is still fresh."""
+    cloud_api = TuyaCloudApi("eu", "client_id", "secret", "user_id")
+    cloud_api.device_list = {"cached_device": {"id": "cached_device"}}
+    cloud_api._last_devices_update = int(time.time())
+    calls = []
+
+    async def mock_make_request(method, url, body=None, headers={}):
+        calls.append((method, url))
+        return {"success": True, "result": []}
+
+    cloud_api.async_make_request = mock_make_request
+
+    result = await cloud_api.async_get_devices_list()
+
+    assert result is None
+    assert calls == []
+    assert cloud_api.device_list == {"cached_device": {"id": "cached_device"}}
+
+
+async def test_stale_regular_refresh_updates_existing_device_list():
+    """Non-forced refresh keeps the previous merge/update behavior."""
+    cloud_api = TuyaCloudApi("eu", "client_id", "secret", "user_id")
+    cloud_api.device_list = {"existing_device": {"id": "existing_device"}}
+    cloud_api._last_devices_update = 0
+
+    async def mock_make_request(method, url, body=None, headers={}):
+        return {
+            "success": True,
+            "result": [
+                {"id": "fresh_device", "name": "Fresh Device"},
+            ],
+        }
+
+    cloud_api.async_make_request = mock_make_request
+
+    result = await cloud_api.async_get_devices_list()
+
+    assert result == "ok"
+    assert cloud_api.device_list == {
+        "existing_device": {"id": "existing_device"},
+        "fresh_device": {"id": "fresh_device", "name": "Fresh Device"},
+    }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,174 @@
+import logging
+from types import SimpleNamespace
+
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DEVICES,
+    CONF_FRIENDLY_NAME,
+    CONF_HOST,
+    CONF_LOCAL_KEY,
+    CONF_NAME,
+)
+
+from custom_components.localtuya import config_flow
+from custom_components.localtuya.config_flow import LocalTuyaOptionsFlowHandler
+from custom_components.localtuya.const import (
+    CONF_GATEWAY_ID,
+    CONF_NODE_ID,
+    CONF_NO_CLOUD,
+    CONF_PROTOCOL_VERSION,
+    CONF_TUYA_GWID,
+    CONF_TUYA_IP,
+    CONF_TUYA_VERSION,
+    DATA_DISCOVERY,
+    DOMAIN,
+)
+
+
+class MockCloudData:
+    def __init__(self, device_list, refreshed_device_list=None, refresh_result="ok"):
+        self.device_list = device_list
+        self.refreshed_device_list = refreshed_device_list or device_list
+        self.refresh_result = refresh_result
+        self.force_update_calls = []
+
+    async def async_get_devices_list(self, force_update=False):
+        self.force_update_calls.append(force_update)
+        self.device_list = self.refreshed_device_list
+        return self.refresh_result
+
+
+def _field_suggested_value(schema, field_name):
+    for field in schema.schema:
+        if field.schema == field_name:
+            return field.description["suggested_value"]
+    raise AssertionError(f"Field {field_name} not found in schema")
+
+
+def _make_options_flow(config_entry, cloud_data, discovered_devices):
+    handler = LocalTuyaOptionsFlowHandler(config_entry)
+    handler.config_entry = config_entry
+    handler.hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                config_entry.entry_id: SimpleNamespace(cloud_data=cloud_data),
+                DATA_DISCOVERY: SimpleNamespace(devices=discovered_devices),
+            }
+        },
+        config_entries=SimpleNamespace(async_entries=lambda domain: []),
+    )
+    handler.async_show_form = lambda **kwargs: kwargs
+    return handler
+
+
+async def test_add_device_refreshes_cloud_before_merging_subdevices(caplog):
+    """Add device should merge against a freshly refreshed Tuya Cloud device list."""
+    local_gateway = {
+        CONF_TUYA_IP: "192.168.1.20",
+        CONF_TUYA_GWID: "gateway_id",
+        CONF_TUYA_VERSION: "3.3",
+    }
+    refreshed_cloud_devices = {
+        "gateway_id": {
+            CONF_LOCAL_KEY: "gateway_key",
+            CONF_NAME: "Gateway",
+            "online": True,
+        },
+        "subdevice_id": {
+            CONF_LOCAL_KEY: "gateway_key",
+            CONF_NAME: "Zigbee Button",
+            CONF_NODE_ID: "node_1",
+            "category": "wxkg",
+            "online": True,
+        },
+    }
+    cloud_data = MockCloudData(
+        device_list={},
+        refreshed_device_list=refreshed_cloud_devices,
+    )
+    config_entry = SimpleNamespace(
+        entry_id="entry_id",
+        data={CONF_NO_CLOUD: False, CONF_DEVICES: {}},
+    )
+    handler = _make_options_flow(
+        config_entry,
+        cloud_data,
+        {"gateway_id": local_gateway},
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=config_flow._LOGGER.name):
+        result = await handler.async_step_add_device()
+
+    assert cloud_data.force_update_calls == [True]
+    assert result["step_id"] == "add_device"
+    assert handler.discovered_devices["subdevice_id"] == {
+        CONF_TUYA_IP: "192.168.1.20",
+        CONF_TUYA_GWID: "subdevice_id",
+        CONF_TUYA_VERSION: "3.3",
+        CONF_NODE_ID: "node_1",
+        CONF_GATEWAY_ID: "gateway_id",
+    }
+    assert (
+        "Merged device list: local/discovered=1 cloud=2 merged=2" in caplog.text
+    )
+
+
+async def test_add_device_logs_cloud_refresh_failure(caplog):
+    """Cloud refresh failures should be logged without blocking the Add device form."""
+    cloud_data = MockCloudData(device_list={}, refresh_result="cloud_error")
+    config_entry = SimpleNamespace(
+        entry_id="entry_id",
+        data={CONF_NO_CLOUD: False, CONF_DEVICES: {}},
+    )
+    handler = _make_options_flow(config_entry, cloud_data, {})
+
+    with caplog.at_level(logging.WARNING, logger=config_flow._LOGGER.name):
+        result = await handler.async_step_add_device()
+
+    assert result["step_id"] == "add_device"
+    assert "Failed to refresh Tuya cloud device list: cloud_error" in caplog.text
+
+
+async def test_configure_device_uses_cloud_defaults_for_entered_device_id(monkeypatch):
+    """A user-entered cloud device id should populate cloud defaults after validation errors."""
+
+    async def mock_validate_input(localtuya_data, user_input):
+        raise config_flow.CannotConnect
+
+    monkeypatch.setattr(config_flow, "validate_input", mock_validate_input)
+
+    cloud_data = MockCloudData(
+        device_list={
+            "cloud_device": {
+                CONF_LOCAL_KEY: "cloud_local_key",
+                CONF_NAME: "Cloud Device",
+            }
+        }
+    )
+    config_entry = SimpleNamespace(
+        entry_id="entry_id",
+        data={CONF_NO_CLOUD: False, CONF_DEVICES: {}},
+    )
+    handler = _make_options_flow(config_entry, cloud_data, {})
+    handler.selected_device = "different_selected_device"
+
+    result = await handler.async_step_configure_device(
+        {
+            CONF_HOST: "192.168.1.30",
+            CONF_DEVICE_ID: "cloud_device",
+            CONF_LOCAL_KEY: "",
+            CONF_FRIENDLY_NAME: "",
+            CONF_PROTOCOL_VERSION: "auto",
+            CONF_NODE_ID: "",
+        }
+    )
+
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert (
+        _field_suggested_value(result["data_schema"], CONF_LOCAL_KEY)
+        == "cloud_local_key"
+    )
+    assert (
+        _field_suggested_value(result["data_schema"], CONF_FRIENDLY_NAME)
+        == "Cloud Device"
+    )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,7 +6,6 @@ from homeassistant.const import (
     CONF_DEVICES,
     CONF_FRIENDLY_NAME,
     CONF_HOST,
-    CONF_LOCAL_KEY,
     CONF_NAME,
 )
 
@@ -14,6 +13,7 @@ from custom_components.localtuya import config_flow
 from custom_components.localtuya.config_flow import LocalTuyaOptionsFlowHandler
 from custom_components.localtuya.const import (
     CONF_GATEWAY_ID,
+    CONF_LOCAL_KEY,
     CONF_NODE_ID,
     CONF_NO_CLOUD,
     CONF_PROTOCOL_VERSION,
@@ -108,9 +108,7 @@ async def test_add_device_refreshes_cloud_before_merging_subdevices(caplog):
         CONF_NODE_ID: "node_1",
         CONF_GATEWAY_ID: "gateway_id",
     }
-    assert (
-        "Merged device list: local/discovered=1 cloud=2 merged=2" in caplog.text
-    )
+    assert "Merged device list: local/discovered=1 cloud=2 merged=2" in caplog.text
 
 
 async def test_add_device_logs_cloud_refresh_failure(caplog):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -47,7 +47,6 @@ def _field_suggested_value(schema, field_name):
 
 def _make_options_flow(config_entry, cloud_data, discovered_devices):
     handler = LocalTuyaOptionsFlowHandler(config_entry)
-    handler.config_entry = config_entry
     handler.hass = SimpleNamespace(
         data={
             DOMAIN: {
@@ -55,8 +54,12 @@ def _make_options_flow(config_entry, cloud_data, discovered_devices):
                 DATA_DISCOVERY: SimpleNamespace(devices=discovered_devices),
             }
         },
-        config_entries=SimpleNamespace(async_entries=lambda domain: []),
+        config_entries=SimpleNamespace(
+            async_entries=lambda domain: [],
+            async_get_known_entry=lambda entry_id: config_entry,
+        ),
     )
+    handler.handler = config_entry.entry_id
     handler.async_show_form = lambda **kwargs: kwargs
     return handler
 


### PR DESCRIPTION
Summary

Refresh the Tuya Cloud device list before merging it with locally discovered devices in the add-device flow.

Problem

The add-device form may use a cached cloud device list. This can prevent recently added gateway subdevices from appearing and can retain devices that were already removed from the Tuya account.

Cloud defaults may also not be applied when the user manually enters a valid cloud device ID that differs from the previously selected device.

Changes
Force a Tuya Cloud device-list refresh before merging cloud and local discovery results.
Replace the cached device list during a forced refresh instead of merging stale entries into it.
Preserve the existing cache behavior for regular non-forced refreshes.
Use the manually entered device ID when resolving cloud defaults.
Add tests for forced refreshes, regular cached refreshes, stale-cache updates, subdevice discovery, refresh failures, and manually entered device IDs.
Runtime impact

This change affects only the configuration flow. It does not add runtime polling or additional requests to configured devices.

Tests
python -m pytest -q tests/test_cloud_api.py tests/test_config_flow.py
python -m pytest -q

All pytest tests now pass.

The remaining Hassfest failure is unrelated to this PR. It is caused by direct URLs already present in `custom_components/localtuya/translations/en.json` on the current upstream `master`.

This PR does not modify the translation file. I have intentionally not included an unrelated translation/config-flow placeholder change in this PR.
