### PR TITLE
Discover Bluetooth sub-devices behind Tuya gateways

### DIFF
--- a/custom_components/localtuya/core/cloud_api.py
+++ b/custom_components/localtuya/core/cloud_api.py
@@ -227,6 +227,27 @@ class TuyaCloudApi:
 
         self.device_list.update({dev["id"]: dev for dev in resp["result"]})
 
+        # Some Tuya gateways do not include their Bluetooth children in the
+        # user device list. Query each possible gateway for its sub-devices;
+        # unsupported devices simply return an unsuccessful response.
+        for gateway_id in tuple(self.device_list):
+            children = await self.async_make_request(
+                "GET", url=f"/v1.0/iot-03/devices/{gateway_id}/sub-devices"
+            )
+            if not children or not children.get("success"):
+                continue
+            for device in children.get("result", []):
+                device.setdefault("gateway_id", gateway_id)
+                self.device_list[device["id"]] = device
+
+        # Tuya LAN sub-devices are authenticated by the gateway's local key.
+        # Normalise that here so the existing gateway matching logic works.
+        for device in self.device_list.values():
+            if gateway_id := device.get("gateway_id"):
+                if gateway := self.device_list.get(gateway_id):
+                    if gateway_key := gateway.get("local_key"):
+                        device["local_key"] = gateway_key
+
         self._last_devices_update = int(time.time())
         return "ok"
 

--- a/tests/test_cloud_api.py
+++ b/tests/test_cloud_api.py
@@ -1,0 +1,32 @@
+"""Tests for the Tuya cloud API client."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.localtuya.core.cloud_api import TuyaCloudApi
+
+
+@pytest.mark.asyncio
+async def test_device_list_includes_gateway_sub_devices():
+    """Bluetooth sub-devices are added and inherit their gateway local key."""
+    cloud = TuyaCloudApi("EU", "client", "secret", "user")
+
+    responses = {
+        "/v1.0/users/user/devices": {
+            "success": True,
+            "result": [{"id": "gateway", "local_key": "gateway-key"}],
+        },
+        "/v1.0/iot-03/devices/gateway/sub-devices": {
+            "success": True,
+            "result": [{"id": "timer", "node_id": "timer-node"}],
+        },
+    }
+    cloud.async_make_request = AsyncMock(
+        side_effect=lambda _method, url: responses.get(url, {"success": False})
+    )
+
+    assert await cloud.async_get_devices_list(force_update=True) == "ok"
+    assert cloud.device_list["timer"]["gateway_id"] == "gateway"
+    assert cloud.device_list["timer"]["node_id"] == "timer-node"
+    assert cloud.device_list["timer"]["local_key"] == "gateway-key"

--- a/tests/test_cloud_api.py
+++ b/tests/test_cloud_api.py
@@ -30,3 +30,27 @@ async def test_device_list_includes_gateway_sub_devices():
     assert cloud.device_list["timer"]["gateway_id"] == "gateway"
     assert cloud.device_list["timer"]["node_id"] == "timer-node"
     assert cloud.device_list["timer"]["local_key"] == "gateway-key"
+
+
+@pytest.mark.asyncio
+async def test_device_list_ignores_devices_without_sub_device_support():
+    """Devices without sub-device support remain in the device list."""
+    cloud = TuyaCloudApi("EU", "client", "secret", "user")
+
+    responses = {
+        "/v1.0/users/user/devices": {
+            "success": True,
+            "result": [{"id": "outlet", "local_key": "outlet-key"}],
+        },
+        "/v1.0/iot-03/devices/outlet/sub-devices": {
+            "success": False,
+            "code": 1106,
+            "msg": "permission deny",
+        },
+    }
+    cloud.async_make_request = AsyncMock(
+        side_effect=lambda _method, url: responses[url]
+    )
+
+    assert await cloud.async_get_devices_list(force_update=True) == "ok"
+    assert cloud.device_list == {"outlet": {"id": "outlet", "local_key": "outlet-key"}}


### PR DESCRIPTION
Tuya's user device list can omit Bluetooth children. Query each top-level device for sub-devices and associate them with the gateway's local key.

This enables local setup for me of a RainPoint TWG009 hub with a TTV102B water timer. I'm running this patch successfully in my HA environment.

Tests: Black, codespell, pytest (23 passed).

The Hassfest errors seem to be pre-existing issues. 

AI assistance: Codex was used to help investigate, implement, and test this change.
