### PR TITLE
fix(cover): guard time-based position calc against None _previous_state

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -295,7 +295,7 @@ class LocalTuyaCover(LocalTuyaEntity, CoverEntity):
             self._config[CONF_POSITIONING_MODE] == MODE_TIME_BASED
             and self._state != self._previous_state
         ):
-            if self._previous_state != self._stop_cmd:
+            if self._previous_state is not None and self._previous_state != self._stop_cmd:
                 # the state has changed, and the cover was moving
                 time_diff = time.time() - self._timer_start
                 pos_diff = round(time_diff / self._config[CONF_SPAN_TIME] * 100.0)


### PR DESCRIPTION
## Problem

For a time-based cover (`positioning_mode: timed`), the first `status_updated()` after (re)connect or a Home Assistant restart runs with `self._previous_state is None`. The position-update branch is guarded only by `self._previous_state != self._stop_cmd`, and `None != stop_cmd` is `True`, so the cover treats the interval between entity init and the first status as phantom travel:

```python
time_diff = time.time() - self._timer_start
pos_diff = round(time_diff / self._config[CONF_SPAN_TIME] * 100.0)
```

This adds a spurious position jump (~1 s / span_time, e.g. ~4–5 % for a 22 s cover) on **every** HA restart/reconnect, so stored positions drift upward over time.

## Fix

Guard the branch on `self._previous_state is not None` as well, so the phantom first-sample update is skipped. No behavior change once the cover has a real previous state.

```python
if self._previous_state is not None and self._previous_state != self._stop_cmd:
```

## Testing

Running on ~15 time-based venetian-blind covers for weeks; positions now survive HA restarts unchanged (previously drifted ~4 %/restart).