### PR TITLE
feat: support native Tuya JSON DP values in set_dp service

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from dataclasses import dataclass
+import json
 import logging
 import time
 from datetime import timedelta
@@ -101,10 +102,14 @@ async def async_setup(hass: HomeAssistant, config: dict):
         if not device.connected:
             raise HomeAssistantError("not connected to device")
         value = event.data[CONF_VALUE]
-        if isinstance(value, dict):
+        if CONF_DP in event.data:
+            if isinstance(value, dict):
+                value = json.dumps(value)
+            await device.set_dp(value, event.data[CONF_DP])
+        elif isinstance(value, dict):
             await device.set_dps(value)
         else:
-            await device.set_dp(value, event.data[CONF_DP])
+            raise HomeAssistantError("dp is required unless value is a mapping of multiple dps")
 
     async def _handle_update_dps(event: ServiceCall):
         """Handle update_dps service call - sends UPDATEDPS (0x12) command."""

--- a/custom_components/localtuya/core/pytuya/__init__.py
+++ b/custom_components/localtuya/core/pytuya/__init__.py
@@ -874,6 +874,8 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             dp_index(int):   dps index to set
             value: new value for the dps index
         """
+        if isinstance(value, dict):
+            value = json.dumps(value)
         return await self.exchange(CMDType.CONTROL, {str(dp_index): value}, nodeID=cid)
 
     async def set_dps(self, dps, cid=None):

--- a/custom_components/localtuya/services.yaml
+++ b/custom_components/localtuya/services.yaml
@@ -23,7 +23,7 @@ set_dp:
           mode: box
     value:
       name: "Value"
-      description: "A new value to set or a list of DP-value pairs. If a list is provided, the target DP will be ignored"
+      description: "The new value for the target DP. If DP is omitted, this must be a mapping of DP-value pairs to set multiple DPs at once. If DP is provided and this is an object, it is sent as a JSON-encoded value for that DP (for Tuya DPs whose native type is JSON)"
       required: true
       example: '{ "1": True, "2": True }'
       selector:


### PR DESCRIPTION
## Summary
- `set_dp` previously treated any `dict` value as a request to set multiple DPs at once (routed to `set_dps`), which made it impossible to write a single DP whose native Tuya type is JSON (an object).
- The service handler now checks the `dp` field first: if present, the value (dict or scalar) is sent to that single DP, with dicts JSON-encoded via `json.dumps`. Only when `dp` is omitted and `value` is a dict does it fall back to the existing multi-DP `set_dps` behavior. If neither condition holds, it now raises a clear `HomeAssistantError` instead of silently misrouting.
- `TuyaProtocol.set_dp` also JSON-encodes dict values directly, so any other caller gets the same support.
- Updated `services.yaml` to document the new `value` semantics for `set_dp`.

## Behavior change
Calling `set_dp` with a dict `value` and no `dp` still works as before (multi-DP set). Calling it with both `dp` and a dict `value` now sets that single DP to the JSON-encoded object instead of being routed to `set_dps`.

## AI disclosure
Claude (Claude Code) was used to help draft this change and its description, per CONTRIBUTING.md guidance to disclose AI assistance.